### PR TITLE
Add Agentic Engineering Framework to Agent infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ Multi-agent coordination, swarm patterns, and autonomous execution loops.
 
 Sandboxes, routers, browser/terminal automation, and extension tools.
 
+- **[Agentic Engineering Framework](https://github.com/DimitriGeelen/agentic-engineering-framework)** — Provider-neutral governance framework for CLI coding agents. Structural enforcement of task-driven workflows, context budget management, antifragile healing loops, and audit compliance. Works with Claude Code, Aider, Cursor, and any file-based agent.
+
 - **[AgentManager](https://github.com/kevinelliott/agentmanager)** — Lightweight CLI for managing multiple agent runs/sessions and workflows.
 
 - **[AgentDeck](https://github.com/agentdeck/agentdeck)** — CLI-driven "deck" of agents with configs/presets for different tasks and repos.


### PR DESCRIPTION
Adds the [Agentic Engineering Framework](https://github.com/DimitriGeelen/agentic-engineering-framework) to the **Agent infrastructure** section.

**What it is:** A provider-neutral governance framework for CLI coding agents — structural enforcement of task-driven workflows, context budget management, antifragile healing loops, and audit compliance. Works with Claude Code, Aider, Cursor, and any file-based agent.

**Why it fits Agent infrastructure:** It's not an agent itself — it's infrastructure that governs how agents operate within a codebase (task gates, commit traceability, tiered approval, session handovers).

- Open source (Apache 2.0)
- Active development (312+ tasks completed using its own governance)
- CLI entry point (`fw`) with 12 subsystems