### PR TITLE
Add Untether — Telegram bridge for 6 CLI coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[agent-terminal](https://github.com/jasonkneen/agent-terminal)** `⭐ 10` — Headless terminal automation for AI agents using node-pty; capture output and send input programmatically.
 
+- **[Untether](https://github.com/littlebearapps/untether)** `⭐ 5` — Telegram bridge for 6 CLI coding agents (Claude Code, Codex, OpenCode, Pi, Gemini CLI, Amp); remote task control via voice or text, progress streaming, interactive permissions, and cost tracking. MIT.
+
 - **[pi-builder](https://github.com/arosstale/pi-builder)** `⭐ 3` — TypeScript monorepo that wraps any installed CLI coding agent (Claude Code, Aider, OpenCode, Codex, Gemini CLI, Goose, Plandex, SWE-agent, Crush, gptme) behind a single interface; capability-based routing, health caching, fallback chains, SQLite persistence, and a streaming OrchestratorService. MIT.
 
 - **[Agentic Engineering Framework](https://github.com/DimitriGeelen/agentic-engineering-framework)** — Provider-neutral governance framework for CLI coding agents. Structural enforcement of task-driven workflows, context budget management, antifragile healing loops, and audit compliance. Works with Claude Code, Aider, Cursor, and any file-based agent.


### PR DESCRIPTION
Adds [Untether](https://github.com/littlebearapps/untether) to the Agent infrastructure section.

Untether bridges CLI coding agents to Telegram, letting you send tasks (voice or text), stream progress, and approve tool calls from your phone.

Supports 6 CLI agents: Claude Code, Codex, OpenCode, Pi, Gemini CLI, and Amp. Engine-agnostic architecture with per-engine feature support (interactive permissions for Claude, approval policies for Codex/Gemini, etc.).

- MIT licensed, Python 3.12+, on PyPI
- `uv tool install untether`