### PR TITLE
Add OneCLI — credential vault for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[pi-builder](https://github.com/arosstale/pi-builder)** `⭐ 3` — TypeScript monorepo that wraps any installed CLI coding agent (Claude Code, Aider, OpenCode, Codex, Gemini CLI, Goose, Plandex, SWE-agent, Crush, gptme) behind a single interface; capability-based routing, health caching, fallback chains, SQLite persistence, and a streaming OrchestratorService. MIT.
 
+- **[OneCLI](https://github.com/onecli/onecli)** — Open-source credential vault for AI agents; Rust HTTP gateway injects API keys transparently so agents never handle raw secrets. Per-agent scoped tokens, AES-256-GCM encryption at rest.
+
 - **[Agentic Engineering Framework](https://github.com/DimitriGeelen/agentic-engineering-framework)** — Provider-neutral governance framework for CLI coding agents. Structural enforcement of task-driven workflows, context budget management, antifragile healing loops, and audit compliance. Works with Claude Code, Aider, Cursor, and any file-based agent.
 
 - **[claude-northstar](https://github.com/Nisarg38/claude-northstar)** — Transforms CLI agents from task executors into autonomous project partners.


### PR DESCRIPTION
Adds [OneCLI](https://github.com/onecli/onecli) to the Agent infrastructure section.

OneCLI is an open-source credential vault for AI agents. A Rust HTTP gateway sits between agents and external APIs, injecting credentials transparently so agents never handle raw keys.

- Apache 2.0 licensed
- Per-agent scoped access tokens
- AES-256-GCM encryption at rest
- Self-hosted via `docker compose up`