### PR TITLE
Add Hermit — governed agent kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ Forkable, extensible, and community-driven. Sorted by GitHub stars. Provider tag
 
 - **[Binharic](https://github.com/CogitatorTech/binharic-cli)** `⭐ 15` — A multi-provider "tech-priest persona" coding agent CLI (stylized, tool-using).
 
+- **[Hermit](https://github.com/heggria/Hermit)** `⭐ 2` — Local-first governed agent kernel with durable task management, approval-based execution, receipts/proofs/rollback, plugin system, and MCP integration. MIT.
+
 - **[CLAII](https://github.com/agencyswarm/CLAII)** — CLI-first AI coding agent with multi-agent orchestration, MCP toolchains, and memory-persistent refactors.
 
 - **[2501 CLI](https://github.com/2501-ai/cli)** — AI-powered autonomous CLI agent for coding, debugging production issues, and DevOps automation.


### PR DESCRIPTION
## Summary

Adds [Hermit](https://github.com/heggria/Hermit) to the **Open Source** section of terminal-native coding agents.

Hermit is a local-first governed agent kernel built in Python (MIT license) with:

- Durable task management with approval-based execution
- Receipts, proofs, and rollback support
- Plugin system with CLI, scheduler, webhook, and MCP surfaces
- Governed execution path: Task → Policy → Approval → Execution → Receipt → Proof

Entry placed in star-count order per contributing guidelines.