### PR TITLE
Add resource: ORCH

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,8 @@ Multi-agent coordination, swarm patterns, and autonomous execution loops. Sorted
 
 - **[wreckit](https://github.com/mikehostetler/wreckit)** `⭐ 120` — Apply the Ralph Wiggum Loop pattern across your roadmap for autonomous agent execution.
 
+- **[ORCH](https://github.com/oxgeneral/ORCH)** `⭐ 9` — CLI orchestrator that manages Claude Code, Codex, and Cursor as a typed task queue with state machine (todo→in_progress→review→done), auto-retry, inter-agent messaging, and TUI dashboard.
+
 ### Agent infrastructure
 
 Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by GitHub stars.


### PR DESCRIPTION
## Add ORCH to Orchestrators & autonomous loops

**[ORCH](https://github.com/oxgeneral/ORCH)** is a CLI runtime for managing AI agent teams with a formal state machine and inter-agent messaging.

### Why it fits here

ORCH sits squarely in "Orchestrators & autonomous loops" — it coordinates multiple CLI coding agents (Claude Code, Codex, OpenCode, Cursor, shell scripts) as a managed team with accountability:

- **State machine**: `todo → in_progress → review → done` with mandatory review gate
- **Auto-retry**: Failed agents transition to `retrying` state automatically
- **Inter-agent messaging**: `orch msg send/broadcast` — agents coordinate directly
- **TUI dashboard**: Ink/React terminal UI for monitoring all agents
- **Goal → task hierarchy**: High-level goals decompose into typed task queues
- **Teams**: Named agent groups with roles
- **Programmatic API**: `@oxgeneral/orch` npm package — embed the engine in any Node.js app

### Entry

```
- **[ORCH](https://github.com/oxgeneral/ORCH)** `⭐ 9` — CLI runtime that manages Claude Code, Codex, OpenCode, Cursor, and shell scripts as a typed AI team. State machine (todo → in_progress → review → done), auto-retry, inter-agent messaging, TUI dashboard, and programmatic npm API. MIT.
```

Placed at the bottom of the section (sorted by stars, 9 stars puts it after wreckit at 120).

### Checklist
- [x] Has a CLI/terminal interface (`npm install -g @oxgeneral/orch`)
- [x] Autonomously reads/writes code and runs commands (via agent adapters)
- [x] Links to an active project (last commit: active development, 1647 tests passing)
- [x] Entry format matches existing entries (name + link + star count + 1-2 line description)