### PR TITLE
Add affiliate-skills — 45 AI agent skills for affiliate marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[pi-builder](https://github.com/arosstale/pi-builder)** `⭐ 3` — TypeScript monorepo that wraps any installed CLI coding agent (Claude Code, Aider, OpenCode, Codex, Gemini CLI, Goose, Plandex, SWE-agent, Crush, gptme) behind a single interface; capability-based routing, health caching, fallback chains, SQLite persistence, and a streaming OrchestratorService. MIT.
 
+- **[affiliate-skills](https://github.com/Affitor/affiliate-skills)** `⭐ 45 skills` — 45 open-source AI agent skills for affiliate marketing. Full 8-stage flywheel with skill chaining. Compatible with Claude Code, Codex, Gemini CLI, Cursor, Windsurf. MIT.
+
 - **[Agentic Engineering Framework](https://github.com/DimitriGeelen/agentic-engineering-framework)** — Provider-neutral governance framework for CLI coding agents. Structural enforcement of task-driven workflows, context budget management, antifragile healing loops, and audit compliance. Works with Claude Code, Aider, Cursor, and any file-based agent.
 
 - **[claude-northstar](https://github.com/Nisarg38/claude-northstar)** — Transforms CLI agents from task executors into autonomous project partners.


### PR DESCRIPTION
## Add affiliate-skills

**Repository:** https://github.com/Affitor/affiliate-skills
**License:** MIT
**Skills:** 45
**Standard:** [agentskills.io](https://agentskills.io)

### What it is

45 open-source AI agent skills for affiliate marketing. Full funnel: research, content, SEO, landing pages, distribution, analytics, automation. Works with Claude Code, ChatGPT, Gemini, Cursor, Windsurf.

### Compatibility

Claude Code, ChatGPT, Gemini CLI, Cursor, Windsurf, OpenClaw, any AI agent.

### Install

```bash
npx skills add Affitor/affiliate-skills
```

### Why include it

- Largest open-source affiliate marketing skill collection (45 skills)
- Follows agentskills.io standard
- Full funnel coverage (8 stages with closed-loop flywheel)
- Works across all major AI coding agents
- Active development, MIT licensed