### PR TITLE
Add brood-box to Agent infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[AgentManager](https://github.com/kevinelliott/agentmanager)** `⭐ 17` — Lightweight CLI for managing multiple agent runs/sessions and workflows.
 
+- **[brood-box](https://github.com/stacklok/brood-box)** `⭐ 11` — Hardware-isolated microVM sandbox for AI coding agents (Claude Code, Codex, OpenCode) with COW snapshot isolation, egress control, and MCP authorization.
+
 - **[agent-terminal](https://github.com/jasonkneen/agent-terminal)** `⭐ 10` — Headless terminal automation for AI agents using node-pty; capture output and send input programmatically.
 
 - **[Untether](https://github.com/littlebearapps/untether)** `⭐ 8` — Telegram bridge for 6 CLI coding agents (Claude Code, Codex, OpenCode, Pi, Gemini CLI, Amp); remote task control via voice or text, progress streaming, interactive permissions, and cost tracking. MIT.


### PR DESCRIPTION
We've been building [brood-box](https://github.com/stacklok/brood-box), a CLI that runs AI coding agents (Claude Code, Codex, OpenCode) inside hardware-isolated microVMs.

The idea is simple: your agent gets a full Linux environment to work in, but it's running inside a KVM microVM. So even if a prompt injection convinces it to `cat ~/.ssh/id_rsa` or `curl` your secrets somewhere... there's nothing to find, and nowhere to send it.

It also does COW snapshot isolation (diff and review every change before it touches your real workspace), DNS-aware egress control, and Cedar-based MCP authorization profiles.

Fits nicely in the Agent infrastructure section alongside the other sandboxing tools.

---
🤖 Generated with [Claude Code](https://claude.ai/code) and [Brood Box](https://github.com/stacklok/brood-box)