### PR TITLE
Add PATAPIM — Terminal IDE for parallel CLI coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,8 @@ Tools for running and managing multiple agent sessions side-by-side. Sorted by G
 
 - **[multi-agent-workflow-kit](https://github.com/laris-co/multi-agent-workflow-kit)** `⭐ 9` — Orchestrate parallel AI agents in isolated git worktrees with shared tmux visibility.
 
+- **[PATAPIM](https://patapim.ai)** — Terminal IDE with a 9-terminal grid for running multiple CLI coding agents simultaneously; features AI state detection, built-in Whisper voice dictation, LAN remote access, and an embedded MCP browser. Built with Electron and node-pty. Freemium.
+
 ### Orchestrators & autonomous loops
 
 Multi-agent coordination, swarm patterns, and autonomous execution loops. Sorted by GitHub stars.


### PR DESCRIPTION
## What is PATAPIM?

[PATAPIM](https://patapim.ai) is a Terminal IDE designed for running multiple CLI coding agents simultaneously in a 9-terminal grid layout. It fits in the **Session managers & parallel runners** section.

## Key features

- **9-terminal grid** — run up to 9 CLI coding agents side-by-side (Claude Code, Codex, Gemini CLI, Aider, etc.)
- **AI state detection** — pattern matching detects when agents are thinking, waiting for input, or idle
- **Built-in Whisper voice dictation** — local speech-to-text via Hugging Face ONNX models
- **LAN remote access** — control sessions from any device on the local network
- **Embedded MCP browser** — browser automation tool available to agents via MCP protocol
- **Built with Electron, xterm.js, and node-pty**

## Checklist

- [x] Has a terminal interface (it IS a terminal environment)
- [x] Designed for running CLI coding agents
- [x] Active project with a valid link
- [x] Entry follows the repo format and is placed at the end of the Session managers section (no GitHub stars to sort by)