### PR TITLE
Add Nex to Agent infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 ---
 
+- **[Nex](https://github.com/nex-crm/nex-as-a-skill)** ★14 — Organizational context and memory for AI agents; connects email, Slack, CRM, and 100+ tools into one knowledge graph with a 60-tool MCP server (`npx @nex-ai/nex`) and persistent memory across agent sessions. MIT.
+
 ## Contributing
 
 PRs welcome! To add an entry, please ensure it meets these criteria:


### PR DESCRIPTION
Adds [Nex](https://github.com/nex-crm/nex-as-a-skill) to the Agent infrastructure section.

Nex provides organizational context and memory for AI agents — connects email, Slack, CRM, and 100+ tools into one knowledge graph with a 60-tool MCP server and persistent memory across agent sessions. MIT licensed.