### PR TITLE
Add OpenHarness — TypeScript terminal coding agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ Forkable, extensible, and community-driven. Sorted by GitHub stars. Provider tag
 
 - **[CLAII](https://github.com/agencyswarm/CLAII)** — CLI-first AI coding agent with multi-agent orchestration, MCP toolchains, and memory-persistent refactors.
 
+- **[OpenHarness](https://github.com/zhijiewong/openharness)** — TypeScript/React+Ink terminal coding agent with 17 tools, 16 slash commands, git auto-commit with /undo, and headless CI mode (`oh run --json`). Works with Ollama, OpenAI, Anthropic, OpenRouter. MIT.
+
 ### OpenClaw ecosystem
 
 Projects built on, forked from, or inspired by [OpenClaw](https://github.com/openclaw/openclaw) — the open-source personal AI assistant. Sorted by GitHub stars.


### PR DESCRIPTION
## OpenHarness 🪼

**GitHub:** https://github.com/zhijiewong/openharness
**npm:** `npm install -g @zhijiewang/openharness`
**License:** MIT

TypeScript/React+Ink terminal coding agent with:
- 17 tools (file ops, bash, web search, task management, notebooks, sub-agents)
- 16 slash commands (/diff, /undo, /commit, /cost, /compact, /plan, /review)
- Git integration: auto-commit AI edits, /undo reverts safely
- Headless CI mode: `oh run "fix tests" --json`
- Works with Ollama, OpenAI, Anthropic, OpenRouter, Qwen, Deepseek or any OpenAI-compatible API
- Permission gates (ask/trust/deny)

Meets all inclusion criteria:
- CLI/terminal interface
- Reads/writes code and runs commands autonomously
- Active project, valid repo