### PR TITLE
Add Darce — ultralight multi-model CLI coding agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ Forkable, extensible, and community-driven. Sorted by GitHub stars. Provider tag
 
 - **[Binharic](https://github.com/CogitatorTech/binharic-cli)** `⭐ 15` — A multi-provider "tech-priest persona" coding agent CLI (stylized, tool-using).
 
+- **[Darce](https://github.com/AmerSarhan/darce-cli)** — Ultralight (14 kB) multi-model CLI agent built with Ink; 7 tools, smart model routing across providers, streaming, session resume, and slash commands. MIT.
+
 - **[CLAII](https://github.com/agencyswarm/CLAII)** — CLI-first AI coding agent with multi-agent orchestration, MCP toolchains, and memory-persistent refactors.
 
 ### OpenClaw ecosystem


### PR DESCRIPTION
**[Darce](https://github.com/AmerSarhan/darce-cli)** — Ultralight (14 kB) multi-model CLI agent built with Ink; 7 tools, smart model routing across providers, streaming, session resume, and slash commands. MIT.

## Why it belongs here

- Terminal-native CLI coding agent (Ink/React TUI)
- 7 built-in tools: Read, Write, Edit, Bash, Glob, Grep, WebFetch
- Multi-model: Qwen, Grok, Claude, Gemini, DeepSeek, Llama via smart routing
- 14 kB on npm — smallest CLI agent by far
- Open source (MIT), actively maintained
- Free tier available

## Links

- npm: https://www.npmjs.com/package/darce-cli
- Website: https://cli.darce.dev
- Install: `npm install -g darce-cli`