### PR TITLE
Add OpenCastle to Orchestrators & autonomous loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,8 @@ Multi-agent coordination, swarm patterns, and autonomous execution loops. Sorted
 
 - **[kodo](https://github.com/ikamensh/kodo)** `⭐ 37` — Autonomous multi-agent coding orchestrator that directs Claude Code, Codex, and Gemini CLI through work cycles with independent architect and tester verification. SWE-bench verified.
 
+- **[OpenCastle](https://github.com/monkilabs/opencastle)** `⭐ 18` — Multi-agent orchestration framework that turns AI coding assistants (Copilot, Cursor, Claude Code, OpenCode, Windsurf, Codex CLI) into 19 coordinated specialist agents. CLI-driven (`npx opencastle init`), with task decomposition, parallel work, and quality gates. MIT.
+
 - **[Bernstein](https://github.com/chernistry/bernstein)** — Deterministic Python orchestrator — spawns parallel AI coding agents (Claude Code, Codex CLI, Gemini CLI), verifies with tests, auto-commits.
 
 - **[ORCH](https://github.com/oxgeneral/ORCH)** `⭐ 9` — CLI orchestrator that manages Claude Code, Codex, and Cursor as a typed task queue with state machine (todo→in_progress→review→done), auto-retry, inter-agent messaging, and TUI dashboard.


### PR DESCRIPTION
Adds [OpenCastle](https://github.com/monkilabs/opencastle) to the **Orchestrators & autonomous loops** section.

OpenCastle is a multi-agent orchestration framework that turns AI coding assistants (GitHub Copilot, Cursor, Claude Code, OpenCode, Windsurf, Codex CLI, Antigravity) into 19 coordinated specialist agents. One command (`npx opencastle init`) sets up agents, skills, and MCP servers tailored to your project.

- **Stars**: 18
- **License**: MIT
- **CLI**: `npx opencastle init`
- **What it does**: Task decomposition, parallel agent work, quality gates, cost-aware model routing
- **Works interactively** (IDE chat) or **automated** (Convoy Engine CLI)