### PR TITLE
Add CliDeck — browser dashboard for parallel CLI coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,8 @@ Tools for running and managing multiple agent sessions side-by-side. Sorted by G
 
 - **[amux](https://github.com/andyrewlee/amux)** `⭐ 56` — Terminal UI designed for running multiple coding agents in parallel.
 
+- **[CliDeck](https://github.com/rustykuntz/clideck)** `⭐ 35` — WhatsApp-like browser dashboard for managing multiple CLI coding agents (Claude Code, Codex, Gemini CLI, OpenCode) with live status detection, session resume, autopilot routing, and full control from a phone while away. MIT.
+
 - **[multi-agent-workflow-kit](https://github.com/laris-co/multi-agent-workflow-kit)** `⭐ 9` — Orchestrate parallel AI agents in isolated git worktrees with shared tmux visibility.
 
 - **[PATAPIM](https://patapim.ai)** — Terminal IDE with a 9-terminal grid for running multiple CLI coding agents simultaneously; features AI state detection, built-in Whisper voice dictation, LAN remote access, and an embedded MCP browser. Built with Electron and node-pty. Freemium.


### PR DESCRIPTION
Adds [CliDeck](https://github.com/rustykuntz/clideck) to the Session managers & parallel runners section.

clideck is a local browser dashboard for managing multiple AI coding agents in a WhatsApp-like interface. it manages terminal sessions with live status detection, session resume, autopilot routing between agents, and full control from a phone while away.

**what makes it different from similar tools:**
- browser-based dashboard, not tmux — chat-style sidebar with live status, message previews, timestamps
- multi-agent: Claude Code, Codex, Gemini CLI, OpenCode, Shell — not locked to one agent
- autopilot routes work between agents autonomously (~50 output tokens per routing decision)
- plugin system (ships with Voice Input, Trim Clip, Autopilot)
- built with xterm.js + node-pty, keys go straight to the agent

- MIT license
- install: `npm install -g clideck`
- docs: https://docs.clideck.dev