### PR TITLE
Add Onepilot — mobile harness for CLI coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,8 @@ Tools for running and managing multiple agent sessions side-by-side. Sorted by G
 
 - **[multi-agent-workflow-kit](https://github.com/laris-co/multi-agent-workflow-kit)** `⭐ 9` — Orchestrate parallel AI agents in isolated git worktrees with shared tmux visibility.
 
+- **[Onepilot](https://onepilotapp.com)** — iOS app for SSHing into remote servers and running CLI coding agents (Claude Code, Codex CLI, Aider) from your phone; mobile harness for terminal-native agents.
+
 - **[PATAPIM](https://patapim.ai)** — Terminal IDE with a 9-terminal grid for running multiple CLI coding agents simultaneously; features AI state detection, built-in Whisper voice dictation, LAN remote access, and an embedded MCP browser. Built with Electron and node-pty. Freemium.
 
 ### Orchestrators & autonomous loops


### PR DESCRIPTION
Adds [Onepilot](https://onepilotapp.com) to the **Session managers & parallel runners** section.

Onepilot is an iOS app that lets you SSH into remote servers and run CLI coding agents (Claude Code, Codex CLI, Aider) from your phone. It acts as a mobile harness for terminal-native agents — useful for monitoring long-running agent sessions, kicking off tasks on the go, or reviewing agent output away from your desk.

Placed after the last starred entry and before PATAPIM, following the sort-by-stars convention.