### PR TITLE
Add Praman — CLI agents for SAP UI5/Fiori test automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[pi-builder](https://github.com/arosstale/pi-builder)** `⭐ 5` — TypeScript monorepo that wraps any installed CLI coding agent (Claude Code, Aider, OpenCode, Codex, Gemini CLI, Goose, Plandex, SWE-agent, Crush, gptme) behind a single interface; capability-based routing, health caching, fallback chains, SQLite persistence, and a streaming OrchestratorService. MIT.
 
+- **[Praman](https://github.com/mrkanitkar/playwright-praman)** `⭐ 5` — Playwright plugin with CLI agents (planner, generator, healer) for SAP UI5/Fiori test automation; 199 typed control proxies, OData V2/V4, AI-driven test generation via MCP. Apache-2.0.
+
 - **[zosma-qa](https://github.com/zosmaai/zosma-qa)** `⭐ 5` — Generates QA agent prompts (planner, generator, healer, analyzer) for CLI coding tools (OpenCode, Claude Code, VS Code Copilot); scaffolds autonomous test workflows across Playwright, Appium, and k6.
 
 - **[Wit](https://github.com/amaar-mc/wit)** `⭐ 4` — Coordination protocol that prevents merge conflicts between parallel AI agents. Locks specific functions (not files) via Tree-sitter AST parsing; agents declare intents, acquire symbol-level locks, and get conflict warnings before writing code. JSON-RPC daemon. MIT.


### PR DESCRIPTION
## Summary

- Adds **[Praman](https://github.com/mrkanitkar/playwright-praman)** (`playwright-praman` on npm) to the **Agent infrastructure** section
- Playwright plugin with CLI agents (planner, generator, healer) that autonomously generate, fix, and maintain SAP UI5/Fiori tests via MCP
- 199 typed control proxies, OData V2/V4, AI-driven test generation, Apache-2.0

## Inclusion criteria checklist

- [x] Has a CLI/terminal interface (`playwright-praman` binary)
- [x] Can read/write code autonomously (generates test files, heals failing tests)
- [x] Points to a valid, active GitHub repo
- [x] Entry includes name + link, star count, 1–2 line description, and license
- [x] Placed in correct star-sorted position (⭐ 5, between pi-builder and zosma-qa)

🤖 Generated with [Claude Code](https://claude.com/claude-code)