### PR TITLE
Add toprank to Agent infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[kasetto](https://github.com/pivoshenko/kasetto)** — A declarative AI agent environment manager, written in Rust.
 
+- **[toprank](https://github.com/nowork-studio/toprank)** — Claude Code plugin with 9 SEO and Google Ads skills. Connects Google Search Console, PageSpeed Insights, and the Google Ads API, then ships fixes (meta tags, JSON-LD schema, keyword bids) directly to source code or CMS. Open-source, MIT.
+
 ---
 
 ## Contributing


### PR DESCRIPTION
Adds **toprank** to Harnesses & orchestration > Agent infrastructure.

toprank is an open-source (MIT) Claude Code plugin providing 9 SEO and Google Ads skills. It extends Claude Code with domain-specific tooling — connects Google Search Console, PageSpeed Insights, and the Google Ads API to audit traffic and wasted ad spend, then ships fixes (meta tags, JSON-LD schema, keyword bids) directly from Claude Code.

- Source: https://github.com/nowork-studio/toprank
- License: MIT
- 100+ stars, actively maintained