### PR TITLE
Add gate4agent - Rust transport for CLI coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[agent-terminal](https://github.com/jasonkneen/agent-terminal)** `⭐ 10` — Headless terminal automation for AI agents using node-pty; capture output and send input programmatically.
 
+- **[gate4agent](https://github.com/ZENG3LD/gate4agent)** `[ZENG3LD]` — Universal Rust transport library for CLI AI agents (Claude Code, Codex, Gemini, OpenCode). Pipe/NDJSON, PTY, and ACP (JSON-RPC 2.0) modes with tokio broadcast fan-out. MIT.
+
 - **[Untether](https://github.com/littlebearapps/untether)** `⭐ 8` — Telegram bridge for 6 CLI coding agents (Claude Code, Codex, OpenCode, Pi, Gemini CLI, Amp); remote task control via voice or text, progress streaming, interactive permissions, and cost tracking. MIT.
 
 - **[pi-builder](https://github.com/arosstale/pi-builder)** `⭐ 5` — TypeScript monorepo that wraps any installed CLI coding agent (Claude Code, Aider, OpenCode, Codex, Gemini CLI, Goose, Plandex, SWE-agent, Crush, gptme) behind a single interface; capability-based routing, health caching, fallback chains, SQLite persistence, and a streaming OrchestratorService. MIT.


### PR DESCRIPTION
Adds gate4agent to the Agent infrastructure section — a universal Rust library for spawning and controlling CLI AI agents (Claude Code, Codex, Gemini, OpenCode) via Pipe, PTY, and ACP transports. Published on crates.io.