### PR TITLE
Add agx — checkpoint-based agent orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,8 @@ Multi-agent coordination, swarm patterns, and autonomous execution loops. Sorted
 
 - **[OpenCastle](https://github.com/monkilabs/opencastle)** `⭐ 18` — Multi-agent orchestration framework that turns AI coding assistants (Copilot, Cursor, Claude Code, OpenCode, Windsurf, Codex CLI) into 19 coordinated specialist agents. CLI-driven (`npx opencastle init`), with task decomposition, parallel work, and quality gates. MIT.
 
+- **[agx](https://github.com/ramarlina/agx)** `⭐ 15` — Checkpoint-based execution engine for AI coding agents; durable Wake→Work→Sleep loops that resume instantly across sessions. Supports Claude Code, Codex CLI, Gemini CLI, and Ollama. CLI + web dashboard + macOS app.
+
 - **[Bernstein](https://github.com/chernistry/bernstein)** — Deterministic Python orchestrator — spawns parallel AI coding agents (Claude Code, Codex CLI, Gemini CLI), verifies with tests, auto-commits.
 
 - **[ORCH](https://github.com/oxgeneral/ORCH)** `⭐ 9` — CLI orchestrator that manages Claude Code, Codex, and Cursor as a typed task queue with state machine (todo→in_progress→review→done), auto-retry, inter-agent messaging, and TUI dashboard.


### PR DESCRIPTION
Adds [agx](https://github.com/ramarlina/agx) to the Orchestrators & autonomous loops section.

**What it does:** Checkpoint-based execution engine that makes AI coding agents durable. Agents run in Wake→Work→Sleep loops — checkpointing state at meaningful boundaries so they resume in O(1) regardless of how long the task has been running.

**Why it fits this list:**
- CLI-native (`npm install -g @mndrk/agx`)
- Orchestrates Claude Code, Codex CLI, Gemini CLI, and Ollama
- 505 commits, 133 merged PRs — many shipped by agents running in wake-work-sleep loops
- Local-first (SQLite), MIT-compatible

Placed by star count (15 stars) between OpenCastle and ORCH.