### PR TITLE
Add Smelt to Open Source agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Forkable, extensible, and community-driven. Sorted by GitHub stars. Provider tag
 
 - **[VibePod](https://github.com/VibePod/vibepod-cli)** `⭐ 28` — Unified CLI for running AI coding agents in isolated Docker containers; zero-config setup, local metrics, HTTP traffic tracking, and an analytics dashboard for side-by-side comparison.
 
-- **[Smelt](https://github.com/leonardcser/smelt)** `⭐ 17` — Rust TUI coding agent. MIT.
+- **[Smelt](https://github.com/leonardcser/smelt)** `⭐ 17` — Rust TUI coding agent; multi-provider (Anthropic, OpenAI, Ollama, GitHub Copilot, any OpenAI-compatible endpoint), four modes (Normal/Plan/Apply/Yolo), granular permission system, parallel subagents, vim keybindings, and headless scriptable mode. MIT.
 
 - **[Binharic](https://github.com/CogitatorTech/binharic-cli)** `⭐ 15` — A multi-provider "tech-priest persona" coding agent CLI (stylized, tool-using).
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ Forkable, extensible, and community-driven. Sorted by GitHub stars. Provider tag
 
 - **[VibePod](https://github.com/VibePod/vibepod-cli)** `⭐ 28` — Unified CLI for running AI coding agents in isolated Docker containers; zero-config setup, local metrics, HTTP traffic tracking, and an analytics dashboard for side-by-side comparison.
 
+- **[Smelt](https://github.com/leonardcser/smelt)** `⭐ 17` — Rust TUI coding agent. MIT.
+
 - **[Binharic](https://github.com/CogitatorTech/binharic-cli)** `⭐ 15` — A multi-provider "tech-priest persona" coding agent CLI (stylized, tool-using).
 
 - **[Darce](https://github.com/AmerSarhan/darce-cli)** — Ultralight (14 kB) multi-model CLI agent built with Ink; 7 tools, smart model routing across providers, streaming, session resume, and slash commands. MIT.


### PR DESCRIPTION
## Summary
- Adds [Smelt](https://github.com/leonardcser/smelt) to the Open Source agents section of the README.

## Test plan
- [x] Verify the link is correct and the entry is properly formatted in the README