### PR TITLE
Add Octomind — open-source CLI agent runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Forkable, extensible, and community-driven. Sorted by GitHub stars. Provider tag
 
 - **[CLAII](https://github.com/agencyswarm/CLAII)** `⭐ 2` — CLI-first AI coding agent with multi-agent orchestration, MCP toolchains, and memory-persistent refactors.
 
+- **[Octomind](https://github.com/muvon/octomind)** — Open-source, model-agnostic AI agent runtime with community tap registry (`developer:rust`, `doctor:blood`, `legal:contracts`), MCP support with runtime self-extension, 13+ providers, and adaptive compression. Written in Rust. Apache-2.0.
 ### OpenClaw ecosystem
 
 Projects built on, forked from, or inspired by [OpenClaw](https://github.com/openclaw/openclaw) — the open-source personal AI assistant. Sorted by GitHub stars.


### PR DESCRIPTION
## Add Octomind

[Octomind](https://github.com/muvon/octomind) is an open-source (Apache 2.0) AI agent runtime written in Rust.

**Key features:**
- Model-agnostic: 13+ providers (OpenAI, Anthropic, Google, AWS, DeepSeek, etc.)
- Community tap registry: `octomind run developer:rust`, `doctor:blood`, `legal:contracts`
- MCP client with runtime self-extension — agents acquire new tools at runtime
- Infinite sessions via adaptive compression
- Zero config — one command to run any domain specialist

**Website:** https://octomind.run
**GitHub:** https://github.com/muvon/octomind
**License:** Apache 2.0