### PR TITLE
Add Relay to Orchestrators & autonomous loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,8 @@ Multi-agent coordination, swarm patterns, and autonomous execution loops. Sorted
 
 - **[sage](https://github.com/youwangd/SageCLI)** `⭐ 2` — Pure bash agent orchestrator (zero frameworks) with runtime-agnostic support (Claude Code, Cline, Codex, Gemini CLI, ACP), wave-based plan execution, git worktree isolation, MCP integration, skills system, headless CI mode, and 295 bats tests. MIT.
 
+- **[Relay](https://github.com/jcast90/relay)** `⭐ 1` — Local-first orchestrator that runs inside your existing Claude or Codex CLI via MCP; classifies a request, decomposes it into tickets with a dependency DAG, dispatches across one or more repos, and supervises with live PR tracking + approval gates. CLI, TUI (ratatui), and GUI (Tauri) dashboards read the same `~/.relay/` files. MIT.
+
 ### Agent infrastructure
 
 Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by GitHub stars.


### PR DESCRIPTION
Adds [Relay](https://github.com/jcast90/relay) to **Harnesses & orchestration → Orchestrators & autonomous loops**.

## Inclusion criteria

- ✅ **CLI / terminal interface** — binary is `rly`; CLI, TUI (ratatui), and GUI (Tauri) dashboards all ship
- ✅ **Reads / writes code + runs commands autonomously** — orchestrates Claude / Codex CLI agents that read, edit, and execute in the user's repos; runs verification commands against an allowlist
- ✅ **Valid, active project** — public, MIT-licensed, actively developed; current release is `0.6.1` on npm as `@jcast90/relay`

## Why this fits the Orchestrators section

Relay is a **local-first multi-agent orchestrator** that classifies an incoming request, decomposes it into tickets with a dependency DAG, and dispatches across one or more repos to Claude / Codex CLI subprocesses (attached via MCP). It supervises long-running work with live PR tracking and optional user-approval gates, and writes a durable decision log to `~/.relay/` — no hosted service, no telemetry.

Differentiators vs. neighboring entries:

- **Multi-repo coordination** — crosslink MCP tools (`crosslink_discover` / `crosslink_send` / `crosslink_poll`) let live agents in different repos message each other; primary + associated repo model at the channel level
- **Three dashboards on one backing store** — CLI, ratatui TUI, and Tauri GUI all read the same `~/.relay/` files, so there is no split brain across surfaces
- **Provider-agnostic** — any OpenAI-compatible or Anthropic-compatible endpoint works with zero code changes (MiniMax, OpenRouter, DeepSeek, Groq, Together, LiteLLM, vLLM)

## Entry placement

Sorted by GitHub stars within the section. Relay is currently at 1 star, placing it immediately after `sage` (2 stars) at the end of the Orchestrators subsection. Happy to reorder if you'd prefer a different sort position.

## Links

- Repo: https://github.com/jcast90/relay
- npm: https://www.npmjs.com/package/@jcast90/relay
- License: MIT

Thanks for maintaining this list!