### PR TITLE
Add openHarness

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ Forkable, extensible, and community-driven. Sorted by GitHub stars. Provider tag
 
 - **[cursor-agent](https://github.com/civai-technologies/cursor-agent)** `⭐ 113` — Python-based agent replicating Cursor's coding assistant capabilities; supports Claude, OpenAI, and local Ollama models.
 
+- **[openHarness](https://github.com/zhijiewong/openharness)** `⭐ 88` — Open-source Claude Code alternative. 78 slash commands, 42 tools, MCP (stdio/HTTP/SSE + OAuth 2.1), hooks, subagents, plan mode. Works with Anthropic/OpenAI/Ollama/llama.cpp/LM Studio. Ships both npm and Python SDK. MIT.
+
 - **[VibePod](https://github.com/VibePod/vibepod-cli)** `⭐ 63` — Unified CLI for running AI coding agents in isolated Docker containers; zero-config setup, local metrics, HTTP traffic tracking, and an analytics dashboard for side-by-side comparison.
 
 - **[QQCode](https://github.com/qnguyen3/qqcode)** `⭐ 51` — Lightweight CLI coding agent in Rust focused on speed, determinism, and developer control; supports skills.


### PR DESCRIPTION
88★ open-source Claude Code alternative. 78 slash commands, 42 tools, MCP (stdio/HTTP/SSE + OAuth 2.1), hooks, subagents, plan mode. Works with Anthropic/OpenAI/Ollama/llama.cpp/LM Studio. Both npm (@zhijiewang/openharness) and Python SDK (openharness-sdk). MIT. Repo: https://github.com/zhijiewong/openharness