### PR TITLE
Add linear-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[claude-northstar](https://github.com/Nisarg38/claude-northstar)** `⭐ 1` — Transforms CLI agents from task executors into autonomous project partners.
 
+- **[linear-cli](https://github.com/phnx-labs/linear-cli)** `⭐ 0` — Single-file Python CLI for Linear (the issue tracker). Zero dependencies. Designed for use as a subagent tool by Claude Code, Codex, Gemini, or Cursor. Includes a SKILL.md for drop-in Claude Code integration. MIT.
+
 ---
 
 ## Contributing


### PR DESCRIPTION
linear-cli (https://github.com/phnx-labs/linear-cli) is a single-file Python CLI for Linear (the issue tracker) with zero third-party dependencies and MIT license. It is designed for both humans and AI coding agents (Claude Code, Codex, Gemini, Cursor) and ships a SKILL.md for drop-in Claude Code integration. Fits the Agent infrastructure section as a task-management subagent tool with no install friction.