### PR TITLE
Add KubeStellar Console kc-agent to Agent infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[kasetto](https://github.com/pivoshenko/kasetto)** `⭐ 62` — A declarative AI agent environment manager, written in Rust.
 
+- **[KubeStellar Console kc-agent](https://github.com/kubestellar/console)** `⭐ 67` — Local agent that bridges CLI coding agents to Kubernetes clusters via MCP; exposes kubeconfig contexts, kubectl, Helm, and multi-cluster operations as MCP tools over WebSocket. Apache-2.0.
+
 - **[claudebox](https://github.com/numtide/claudebox)** `⭐ 45` — Sandboxed environment for Claude Code (focused on isolation/safety).
 
 - **[skill-optimizer](https://github.com/fastxyz/skill-optimizer)** `⭐ 38` — CLI tool that benchmarks SDK, CLI, and MCP guidance docs (SKILL.md) across multiple LLMs using static action + argument matching. Iteratively rewrites docs until every configured model meets a PASS/FAIL score floor. MIT.


### PR DESCRIPTION
## What

Adds [KubeStellar Console kc-agent](https://github.com/kubestellar/console) to the **Agent infrastructure** section.

## Why it belongs here

kc-agent is a local agent that bridges CLI coding agents to Kubernetes clusters via the Model Context Protocol (MCP). It runs as a lightweight WebSocket server (`localhost:8585`) and exposes:

- **kubeconfig contexts** — list/switch between clusters
- **kubectl** — run any kubectl command against any cluster  
- **Helm** — chart operations (install, upgrade, list, rollback)
- **Multi-cluster operations** — fan-out queries across clusters with deduplication

Any terminal-native coding agent (Claude Code, Codex, Copilot CLI, OpenCode, etc.) can connect to kc-agent as an MCP server and manage Kubernetes resources natively from the command line.

## Placement

Added to **Agent infrastructure** (sorted by stars: 67⭐, between kasetto at 62⭐ and claudebox at 45⭐).

## Checklist

- [x] Entry follows existing format: `- **[Name](url)** \`⭐ N\` — description. License.`
- [x] Sorted by star count within section
- [x] Description is factual and concise
- [x] Apache-2.0 license noted