### PR TITLE
Add CLITrigger to session managers & parallel runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,8 @@ Tools for running and managing multiple agent sessions side-by-side. Sorted by G
 
 - **[multi-agent-workflow-kit](https://github.com/laris-co/multi-agent-workflow-kit)** `⭐ 9` — Orchestrate parallel AI agents in isolated git worktrees with shared tmux visibility.
 
+- **[CLITrigger](https://github.com/HyperAITeam/CLITrigger)** `⭐ 4` — Self-hosted web UI for orchestrating Claude Code, Codex, and Gemini CLIs in parallel git worktrees. Features multi-agent discussion mode (architect/developer/reviewer debate before implementation), cross-project Morning Review Queue, scheduled execution with rate-limit auto-recovery, and a built-in Git client. npm install. MIT.
+
 - **[PATAPIM](https://patapim.ai)** — Terminal IDE with a 9-terminal grid for running multiple CLI coding agents simultaneously; features AI state detection, built-in Whisper voice dictation, LAN remote access, and an embedded MCP browser. Built with Electron and node-pty. Freemium.
 
 ### Orchestrators & autonomous loops


### PR DESCRIPTION
  Adds CLITrigger — a self-hosted web UI for orchestrating Claude/Codex/Gemini CLIs in parallel git worktrees with multi-agent discussion mode. 
 
  - Repo: https://github.com/HyperAITeam/CLITrigger 
  - npm: https://www.npmjs.com/package/clitrigger 
  - License: MIT 
 
  Slotted in the Session managers & parallel runners section by current star count (4). 