### PR TITLE
Add Not Human Search to agent infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[linear-cli](https://github.com/phnx-labs/linear-cli)** `⭐ 0` — Single-file Python CLI for Linear (the issue tracker), zero dependencies. Designed for use as a subagent tool by Claude Code, Codex, Gemini, or Cursor; ships a SKILL.md for drop-in Claude Code integration. MIT.
 
+- **[Not Human Search](https://github.com/unitedideas/nothumansearch)** `⭐ 0` — MCP server and API for CLI agents to search agent-ready tools and verify MCP/OpenAPI/llms.txt surfaces before wiring external services into a repo. Public endpoint: `https://nothumansearch.ai/mcp`.
+
 ---
 
 ## Contributing


### PR DESCRIPTION
Adds Not Human Search under Agent infrastructure.

Fit:
- It exposes a live MCP server and API at nothumansearch.ai/mcp.
- CLI coding agents can use it to discover agent-ready external tools and verify MCP/OpenAPI/llms.txt surfaces before integrating them.

Validation:
- GitHub project link returns HTTP 200.
- MCP endpoint answered a real tools/list JSON-RPC request.