### PR TITLE
Add Aeon to Orchestrators & autonomous loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,8 @@ Multi-agent coordination, swarm patterns, and autonomous execution loops. Sorted
 
 - **[loom](https://github.com/ghuntley/loom)** `⭐ 1.3k` — Infrastructure enabling autonomous loops to evolve products via multi-agent coordination.
 
+- **[Aeon](https://github.com/aaronjmars/aeon)** `⭐ 255` — Autonomous agent framework that runs unattended on GitHub Actions; orchestrates Claude Code across 90+ skills (research, dev, crypto, productivity) on cron or reactive triggers, with quality scoring (1–5 via Haiku), persistent memory, and a self-healing loop (`heartbeat` → `skill-health` → `skill-evals` → `skill-repair` → `self-improve`). MCP + A2A integrations. MIT.
+
 - **[Bernstein](https://github.com/chernistry/bernstein)** `⭐ 206` — Deterministic Python orchestrator — spawns parallel AI coding agents (Claude Code, Codex CLI, Gemini CLI), verifies with tests, auto-commits.
 
 - **[wreckit](https://github.com/mikehostetler/wreckit)** `⭐ 126` — Apply the Ralph Wiggum Loop pattern across your roadmap for autonomous agent execution.


### PR DESCRIPTION
Adds [Aeon](https://github.com/aaronjmars/aeon) to **Harnesses & orchestration → Orchestrators & autonomous loops**, inserted by star-rank between `loom` (1.3k) and `Bernstein` (206) — Aeon currently sits at ~255 stars.

## Why it fits the section

Aeon orchestrates Claude Code (`claude -p`) across 90+ skills running on GitHub Actions cron + reactive triggers. It's an autonomous loop runner in the broader sense: `heartbeat` runs 3x daily, detects failed/stuck/chronically-broken skills, and fires `skill-repair` automatically (reactive trigger `when: consecutive_failures >= 3`). Identical pattern to ralph-* style loops, but scheduled instead of run-until-done.

## Inclusion criteria check

- ✅ **CLI/terminal interface** — `./aeon` launches local dashboard, `./onboard`, `./add-skill`, `./add-mcp`, `./add-a2a`, `./export-skill`. Skills run via `claude -p -` identically locally and in Actions.
- ✅ **Reads/writes code, runs commands** — skills include `pr-review`, `auto-merge`, `code-health`, `changelog`, `vuln-scanner`, `workflow-security-audit`, `spawn-instance`, `fork-fleet`. PRs are created against the agent's own repo and others (via `GH_GLOBAL` PAT).
- ✅ **Active project** — 255 stars, 38 forks, MIT.

## Format

```
- **[Aeon](https://github.com/aaronjmars/aeon)** `⭐ 255` — Autonomous agent framework that runs unattended on GitHub Actions; orchestrates Claude Code across 90+ skills (research, dev, crypto, productivity) on cron or reactive triggers, with quality scoring (1–5 via Haiku), persistent memory, and a self-healing loop (`heartbeat` → `skill-health` → `skill-evals` → `skill-repair` → `self-improve`). MCP + A2A integrations. MIT.
```