### PR TITLE
Add AgentPlane to agent infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[Nex](https://github.com/nex-crm/nex-as-a-skill)** `⭐ 40` — Organizational context and memory for AI agents; connects email, Slack, CRM, and 100+ tools into one knowledge graph with a 60-tool MCP server (`npx @nex-ai/nex`) and persistent memory across agent sessions. MIT.
 
-- **[AgentPlane](https://github.com/basilisk-labs/agentplane)** `⭐ 39` — Git-native workflow control layer for Claude Code, Codex, Cursor, Aider, and other CLI coding-agent workflows. Adds task, plan, approval, verification, and finish records inside the repository. MIT.
+- **[AgentPlane](https://github.com/basilisk-labs/agentplane)** `⭐ 39` — Git-native workflow control layer for repo-local coding-agent work. Adds task, plan, approval, verification, and finish records inside the repository. MIT.
 
 - **[brood-box](https://github.com/stacklok/brood-box)** `⭐ 29` — Hardware-isolated microVM sandbox for AI coding agents (Claude Code, Codex, OpenCode) with COW snapshot isolation, egress control, and MCP authorization.
 

--- a/README.md
+++ b/README.md
@@ -345,6 +345,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[Nex](https://github.com/nex-crm/nex-as-a-skill)** `⭐ 40` — Organizational context and memory for AI agents; connects email, Slack, CRM, and 100+ tools into one knowledge graph with a 60-tool MCP server (`npx @nex-ai/nex`) and persistent memory across agent sessions. MIT.
 
+- **[AgentPlane](https://github.com/basilisk-labs/agentplane)** `⭐ 39` — Git-native workflow control layer for Claude Code, Codex, Cursor, Aider, and other CLI coding-agent workflows. Adds task, plan, approval, verification, and finish records inside the repository. MIT.
+
 - **[brood-box](https://github.com/stacklok/brood-box)** `⭐ 29` — Hardware-isolated microVM sandbox for AI coding agents (Claude Code, Codex, OpenCode) with COW snapshot isolation, egress control, and MCP authorization.
 
 - **[AgentManager](https://github.com/kevinelliott/agentmanager)** `⭐ 23` — Lightweight CLI for managing multiple agent runs/sessions and workflows.


### PR DESCRIPTION
Hi - I would like to add AgentPlane to this list.

Disclosure: I maintain AgentPlane.

Why it fits:
AgentPlane is not another coding agent and not a hosted agent platform. It is a local-first, Git-native workflow control layer for repo-local coding-agent work. It records task state, accepted plans, approval state, verification evidence, finish/closure records, and Git revision links inside the repository.

Suggested category:
Harnesses & orchestration -> Agent infrastructure. AgentPlane has a CLI/terminal workflow and wraps existing coding-agent work with repo-local workflow state rather than replacing the underlying agent.

Entry added:
AgentPlane - Git-native workflow control layer for repo-local coding-agent work. Adds task, plan, approval, verification, and finish records inside the repository.

Verification:
- `git diff --check`

Note: I did not run `scripts/update-stars.py` because this repository's contributing section only asks for star-count placement, and running the updater would refresh many unrelated entries.

Happy to adjust category, wording, or remove if this is outside scope.
