### PR TITLE
Add Bring Your AI to Agent infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[linear-cli](https://github.com/phnx-labs/linear-cli)** `⭐ 0` — Single-file Python CLI for Linear (the issue tracker), zero dependencies. Designed for use as a subagent tool by Claude Code, Codex, Gemini, or Cursor; ships a SKILL.md for drop-in Claude Code integration. MIT.
 
+- **[Bring Your AI](https://github.com/unitedideas/bringyour-mcp)** `⭐ 0` — Public MCP metadata and migration-audit artifacts for a local-first Claude Code -> Codex harness mover; paired docs cover AGENTS.md/CLAUDE.md differences and Codex import checks without uploading harness files.
+
 ---
 
 ## Contributing


### PR DESCRIPTION
Adds Bring Your AI under Agent infrastructure for a local Claude Code -> Codex migration path.

The fit here is harness portability: moving rules, skills, hooks, MCP config, and migration checks without treating one instruction file as the whole setup.

Practical docs:
- https://bringyour.ai/claude-code-to-codex
- https://bringyour.ai/agents-md-claude-md
- https://bringyour.ai/codex-import-checklist

Public MCP/artifact repo:
- https://github.com/unitedideas/bringyour-mcp
