### PR TITLE
Add agentpreflight to Agent infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[Not Human Search](https://github.com/unitedideas/nothumansearch)** `⭐ 0` — Search engine for AI agents that ranks sites by agentic readiness (llms.txt, OpenAPI, MCP, ai-plugin); 8,000+ indexed sites exposed via MCP server, REST API, and full-text search. Lets agents discover and verify external services before wiring them into a repo. MIT.
 
+- **[agentpreflight](https://github.com/kaylacar/agentpreflight)** `⭐ 0` — Pre-execution validation gate for AI agent tool calls. 13 rule sets across security (filesystem, git, secrets, network, parallel) and workflow discipline (naming, scope, editorial, session, time-estimation, prewrite, release). Hooks into Claude Code, Codex, OpenClaw. Zero runtime dependencies. MIT.
+
 ---
 
 ## Contributing


### PR DESCRIPTION
Adds [agentpreflight](https://github.com/kaylacar/agentpreflight) to the Agent infrastructure section.

**What it is:** Pre-execution validation gate for AI agent tool calls. Sits between intent and execution — intercepts each tool call, validates it, blocks unsafe ones.

**Why it fits:** The Agent infrastructure section covers extension tools, sandboxes, and validators. agentpreflight is an in-process gate (hooks for Claude Code, Codex, OpenClaw). 13 rule sets across security (filesystem/git/secrets/network/parallel) and workflow discipline (naming/scope/editorial/session/time-estimation/prewrite/release).

**Notable:** Zero runtime dependencies (only Node builtins). 140 tests. MIT.

Inclusion criteria check:
- CLI/terminal interface — yes, multiple bins (`agentpreflight-exec`, `-codex`, `-setup-hooks`, etc.) plus npm SDK
- Reads/writes/runs autonomously — gates the agents that do
- Active — v0.1.3 on npm, recent commits

Entry placed at the bottom of Agent infrastructure (matches its current 0-star position).