### PR TITLE
Add Prismfy Wizard: install live web search rules into local AI agent workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ Multi-agent coordination, swarm patterns, and autonomous execution loops. Sorted
 
 Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by GitHub stars.
 
+- [Prismfy Wizard](https://github.com/prismfy/prismfy-wizard) — CLI that installs persistent live web search rules into local AI agent workflows by adding a `prismfy-search` command and managed search-policy blocks to agent instruction files.
 - **[claude-code-router](https://github.com/musistudio/claude-code-router)** `⭐ 33.4k` — Use Claude Code as a foundation while routing to alternative providers/endpoints.
 
 - **[agent-browser](https://github.com/vercel-labs/agent-browser)** `⭐ 31.6k` — Headless browser automation CLI for agents (useful as a tool plugin for coding agents).


### PR DESCRIPTION
## What I'm adding

I'd like to add [Prismfy Wizard](https://github.com/prismfy/prismfy-wizard), an open-source CLI for local AI agent workflows.

It installs:
- a local `prismfy-search` command
- managed search-policy blocks in agent instruction files
- selectable verification modes (`minimal`, `balanced`, `research`, `strict`)

This helps coding and research agents verify current external facts instead of relying only on model memory.

## Suggested entry

- [Prismfy Wizard](https://github.com/prismfy/prismfy-wizard) — CLI that installs persistent live web search rules into local AI agent workflows by adding a `prismfy-search` command and managed search-policy blocks to agent instruction files.
