### PR TITLE
Add great_cto — 34-agent SDLC orchestrator (multi-platform: Claude Code, Cursor, Codex, Aider, Continue)

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,8 @@ Multi-agent coordination, swarm patterns, and autonomous execution loops. Sorted
 
 - **[agx](https://github.com/ramarlina/agx)** `⭐ 20` — Checkpoint-based execution engine for AI coding agents; durable Wake→Work→Sleep loops that resume instantly across sessions. Supports Claude Code, Codex CLI, Gemini CLI, and Ollama. CLI + web dashboard + macOS app.
 
+- **[great_cto](https://github.com/avelikiy/great_cto)** `⭐ 8` — Engineering management layer for 34 specialist AI agents running the full SDLC pipeline (architect, pm, senior-dev, code-reviewer, qa, security, devops, l3-support + 18 archetype-specific reviewers). 25 archetypes auto-detected with compliance gates (PCI-DSS, HIPAA, FedRAMP, GDPR, EU AI Act). Multi-platform — runs in Claude Code, Cursor, Codex CLI, Aider, Continue via AGENTS.md + MCP. Local kanban board (`great-cto board`), built-in OWASP LLM Top 10 scanner, honest cost metrics. MIT.
+
 - **[sage](https://github.com/youwangd/SageCLI)** `⭐ 3` — Pure bash agent orchestrator (zero frameworks) with runtime-agnostic support (Claude Code, Cline, Codex, Gemini CLI, ACP), wave-based plan execution, git worktree isolation, MCP integration, skills system, headless CI mode, and 295 bats tests. MIT.
 
 - **[Relay](https://github.com/jcast90/relay)** `⭐ 3` — Local-first orchestrator that runs inside your existing Claude or Codex CLI via MCP; classifies a request, decomposes it into tickets with a dependency DAG, dispatches across one or more repos, and supervises with live PR tracking + approval gates. CLI, TUI (ratatui), and GUI (Tauri) dashboards share `~/.relay/` state. MIT.


### PR DESCRIPTION
Adding [great_cto](https://github.com/avelikiy/great_cto) to **Orchestrators & autonomous loops**.

### What it is
Engineering management layer that orchestrates **34 specialist AI agents** through the full SDLC — architect, pm, senior-dev, code-reviewer, qa-engineer, security-officer, performance-engineer, devops, l3-support, plus 18 archetype-specific reviewers (PCI, oracle/web3, gov-public, edtech, mlops, fintech, etc).

### Why it fits this section

- **Multi-agent coordination** — 8 pipeline agents + 18 reviewers + 8 utility agents with explicit handoffs (gates), per-stage Beads task lifecycle, verdict trails
- **Runtime-agnostic** — works identically in Claude Code, Cursor, Codex CLI, Aider, and Continue via AGENTS.md + MCP (`great-cto adapt --platform`)
- **Autonomous loop** — `/start "feature"` triggers the full pipeline; you make 2 decisions per feature (gate:arch, gate:ship), agents handle the rest
- **Local-first** — no SaaS, no cloud, no telemetry. State in `~/.great_cto/` and `.great_cto/` (just files in git)

### Differentiation vs others in this section

- 25 **archetypes auto-detected** with compliance gates (PCI-DSS, HIPAA, FedRAMP, GDPR, EU AI Act, COPPA) — picks the right reviewer agents in 2 sec from `package.json` / `pyproject.toml` / `Cargo.toml`
- **Built-in OWASP LLM Top 10 scanner** (24 rules + SARIF) — `great-cto scan ./`
- **Local kanban board** — `great-cto board` opens 6 views at `localhost:3141` (tasks/gates/cost/memory/agents/logs); SessionEnd hook auto-captures session logs
- **Honest cost metrics** — €0.27/AI-hr · €75/human-hr · ~270× ratio, all configurable, math is auditable

### Placement

Sorted by stars (⭐ 8) — slotted between agx (⭐ 20) and sage (⭐ 3).

Happy to adjust framing, category, or move to a different section if you'd prefer. Thanks for maintaining this list!