### PR TITLE
Add Dakera to Agent infrastructure: self-hosted MCP memory server

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[EchoCoding](https://github.com/launsion-boop/EchoCoding)** `⭐ 21` — Audio layer for CLI coding agents with hook-triggered SFX, ambient soundscape, and optional cloud TTS/ASR voice interaction for Codex and Claude Code workflows.
 
+- **[Dakera](https://github.com/dakera-ai/dakera-mcp)** — Self-hosted MCP-native memory server for CLI coding agents. Gives agents persistent, decay-weighted episodic memory across sessions via 83 MCP tools — works with Claude Code, Cursor, and any MCP-compatible CLI agent. RocksDB + HNSW backend, 87.8% LoCoMo benchmark, Docker Compose deploy, Apache-2.0.
+
 - **[agent-terminal](https://github.com/jasonkneen/agent-terminal)** `⭐ 10` — Headless terminal automation for AI agents using node-pty; capture output and send input programmatically.
 
 - **[zosma-qa](https://github.com/zosmaai/zosma-qa)** `⭐ 6` — Generates QA agent prompts (planner, generator, healer, analyzer) for CLI coding tools (OpenCode, Claude Code, VS Code Copilot); scaffolds autonomous test workflows across Playwright, Appium, and k6.


### PR DESCRIPTION
## Summary

Adds [Dakera](https://github.com/dakera-ai/dakera-mcp) to the **Agent infrastructure** section.

Dakera is a **self-hosted MCP-native memory server** that gives CLI coding agents persistent, long-term memory across sessions — a foundational piece of agent infrastructure that complements sandboxes, routers, and automation tools:

- **Works with Claude Code, Cursor, and any MCP-compatible CLI agent** — standard MCP protocol, no vendor lock-in
- **83 MCP tools** for the full memory lifecycle: store, recall, search, decay, consolidate, manage sessions
- **Decay-weighted retrieval** — older memories naturally fade, keeping recent/important context prioritised
- **87.8% LoCoMo benchmark** — evaluated on the industry standard for long-term conversational memory
- **RocksDB + HNSW** — production-grade persistence and fast vector similarity search
- **Docker Compose one-command deploy** — self-hosted, no cloud dependency, Apache-2.0

This fills the agent memory infrastructure gap in the list.