### PR TITLE
Add AgentTier to Agent infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[Agentic Engineering Framework](https://github.com/DimitriGeelen/agentic-engineering-framework)** `⭐ 5` — Provider-neutral governance framework for CLI coding agents. Structural enforcement of task-driven workflows, context budget management, antifragile healing loops, and audit compliance. Works with Claude Code, Aider, Cursor, and any file-based agent.
 
+- **[AgentTier](https://github.com/agenttier/agenttier)** `⭐ 4` — Kubernetes-native sandbox runtime for AI coding agents and human developers. Same Sandbox CRD provisions a Pod + PVC + NetworkPolicy with optional gVisor isolation; the `agenttier` Go CLI runs `mode: agent` invokes that stream stdout/stderr/exit as SSE. Reference templates ship for Claude Code + Bedrock and LangGraph. Apache-2.0.
+
 - **[OSOP](https://github.com/Archie0125/osop-agent-rules)** `⭐ 1` — Universal workflow logging protocol for CLI coding agents; produces `.osop` workflow definitions and `.osoplog.yaml` execution records. Supports Claude Code, Codex, Cursor, Windsurf, Aider, Cline, Roo Code, Devin, and OpenClaw. Includes a [visual editor](https://osop-editor.vercel.app) and [spec](https://github.com/Archie0125/osop-spec).
 
 - **[claude-northstar](https://github.com/Nisarg38/claude-northstar)** `⭐ 1` — Transforms CLI agents from task executors into autonomous project partners.


### PR DESCRIPTION
This PR adds [AgentTier](https://github.com/agenttier/agenttier) under `Harnesses & orchestration → Agent infrastructure`.

AgentTier is a Kubernetes-native sandbox runtime where the same `Sandbox` CRD provisions a Pod + PVC + default-deny NetworkPolicy (with optional gVisor isolation) for both human developers and AI coding agents. The `agenttier` Go CLI calls `mode: agent` invokes that stream stdout/stderr/exit as Server-Sent Events. Reference templates ship for Claude Code + AWS Bedrock and LangGraph. Apache-2.0.

**Compliance with inclusion requirements:**

- ✅ **CLI / terminal interface** — `agenttier` Go CLI distributed as GitHub Release binaries for linux/darwin/windows × amd64/arm64. Subcommands include `agenttier configure` (uploads files + runs install) and `agenttier invoke` (streams output to stdout, exits with the same exit code so it composes in shell pipelines).
- ✅ **Reads/writes code, runs commands** — sandboxes have a writable PVC; the `mode: agent` SSE invoke runs an entrypoint inside the sandbox that can read, write, and execute code.
- ✅ **Valid, active project** — last release v0.3.0 (2026-05-13), CI green.

**Entry format:**

- Name + GitHub link ✅
- Star count: ⭐ 4 (verified via API)
- 1–2 line description ✅
- License tag (Apache-2.0) ✅

**Sort placement:** between `Agentic Engineering Framework` (⭐ 5) and `OSOP` (⭐ 1) within the Agent infrastructure section, matching the section's descending-by-stars sort.
