### PR TITLE
Add Galley to Orchestrators & autonomous loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,8 @@ Multi-agent coordination, swarm patterns, and autonomous execution loops. Sorted
 
 - **[Relay](https://github.com/jcast90/relay)** `⭐ 3` — Local-first orchestrator that runs inside your existing Claude or Codex CLI via MCP; classifies a request, decomposes it into tickets with a dependency DAG, dispatches across one or more repos, and supervises with live PR tracking + approval gates. CLI, TUI (ratatui), and GUI (Tauri) dashboards share `~/.relay/` state. MIT.
 
+- **[Galley](https://github.com/shinpr/galley)** `⭐ 1` — Local-first runtime for supervised AI coding tasks with isolated git worktrees, supervisor review against acceptance criteria, retry/escalate loops, on-disk run evidence, and PR handoff. Supports Codex CLI and Claude Code. MIT.
+
 ### Agent infrastructure
 
 Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by GitHub stars.


### PR DESCRIPTION
Adds [Galley](https://github.com/shinpr/galley) to the **Harnesses & orchestration → Orchestrators & autonomous loops** section.

**What it does:** Local-first runtime for supervised AI coding tasks. The `galleyd` daemon picks up YAML tasks, runs Codex CLI or Claude Code in an isolated git worktree per task, then has a supervisor (Codex or Claude) review the result against acceptance criteria, retry on revision, or escalate when human judgment is needed. Accepted work can be committed, pushed, and opened as a PR; the recorded PR author can requeue revisions from PR comments. Every attempt records command plans, executor output, diffs, and supervisor verdicts under `runs/<run-id>/` for after-the-fact audit.

**Why it fits this list:**
- CLI-native (`galley` + `galleyd` binaries); install via `go install github.com/shinpr/galley/cmd/galley@latest` or the install script
- Executes against repository code through Codex CLI or Claude Code inside a worktree, runs the project's checks, and can commit
- Active project — v0.5.0 released 2026-05-15, MIT, CI passing

Placed at the bottom of the section after `Relay` (★3). The weekly star-refresh workflow will re-sort it.

**Entry:**

```
- **[Galley](https://github.com/shinpr/galley)** `⭐ 1` — Local-first runtime for supervised AI coding tasks with isolated git worktrees, supervisor review against acceptance criteria, retry/escalate loops, on-disk run evidence, and PR handoff. Supports Codex CLI and Claude Code. MIT.
```