### PR TITLE
Add click-to-mcp to Agent infrastructure section

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[Agentic Engineering Framework](https://github.com/DimitriGeelen/agentic-engineering-framework)** `⭐ 5` — Provider-neutral governance framework for CLI coding agents. Structural enforcement of task-driven workflows, context budget management, antifragile healing loops, and audit compliance. Works with Claude Code, Aider, Cursor, and any file-based agent.
 
+- **[click-to-mcp](https://github.com/Coding-Dev-Tools/click-to-mcp)** `⭐ 3` — Automatically convert any Click or Typer CLI into an MCP server; bridges existing Python CLIs to the Model Context Protocol for use with Claude Code, Codex, OpenCode, and other MCP clients. MIT.
+
 - **[OSOP](https://github.com/Archie0125/osop-agent-rules)** `⭐ 1` — Universal workflow logging protocol for CLI coding agents; produces `.osop` workflow definitions and `.osoplog.yaml` execution records. Supports Claude Code, Codex, Cursor, Windsurf, Aider, Cline, Roo Code, Devin, and OpenClaw. Includes a [visual editor](https://osop-editor.vercel.app) and [spec](https://github.com/Archie0125/osop-spec).
 
 - **[claude-northstar](https://github.com/Nisarg38/claude-northstar)** `⭐ 1` — Transforms CLI agents from task executors into autonomous project partners.


### PR DESCRIPTION
## click-to-mcp

Automatically converts any Python Click or Typer CLI into an MCP server, bridging existing command-line tools to the Model Context Protocol ecosystem.

- **Repo:** https://github.com/Coding-Dev-Tools/click-to-mcp
- **Stars:** 3 (new project)
- **License:** MIT
- **Category:** Agent infrastructure — MCP server generation tool

### Why it fits

click-to-mcp is an infrastructure tool that extends the MCP ecosystem by making any existing CLI immediately available as an MCP server. This is directly useful for CLI coding agents (Claude Code, Codex, OpenCode, etc.) that connect to MCP servers for tool access. One command () generates a fully compatible stdio MCP server from any Click/Typer CLI.

Placed after the 5-star entries, before the 1-star entries, per the sorting convention.