### PR TITLE
Add cctrack to Agent infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[Not Human Search](https://github.com/unitedideas/nothumansearch)** `⭐ 0` — Search engine for AI agents that ranks sites by agentic readiness (llms.txt, OpenAPI, MCP, ai-plugin); 8,000+ indexed sites exposed via MCP server, REST API, and full-text search. Lets agents discover and verify external services before wiring them into a repo. MIT.
 
+- **[cctrack](https://github.com/nvwalj/claude-cost-tracker)** `⭐ 0` — Per-project cost tracker for Claude Code. Walks `~/.claude/projects/**/*.jsonl`, parses assistant `usage` blocks, multiplies tokens (input / output / cache-read / cache-write) by published Claude 4.x prices, prints a per-project or per-day dollar breakdown. Single-file Python, stdlib only. MIT.
+
 ---
 
 ## Contributing


### PR DESCRIPTION
## Project: cctrack

**Repo:** https://github.com/nvwalj/claude-cost-tracker

### What it is

Per-project cost tracker for Claude Code. Walks `~/.claude/projects/**/*.jsonl` (the same NDJSON session-telemetry files Claude Code already writes), parses every assistant `message.usage` block, multiplies tokens (input / output / cache-read / cache-write 5m / cache-write 1h) by published Claude 4.x prices, and prints a per-project or per-day dollar breakdown.

### How it slots into this list

It's not an agent itself — it's the kind of sidecar that the "Agent infrastructure" section already lists (observability/management around CLI coding agents). Closest analogues already in the list: AgentManager (lightweight CLI for managing agent runs/sessions), brood-box (cost-tracking via VM logs in some setups), claude-code-tools (workflow utilities).

### Inclusion criteria

- ✅ CLI / terminal interface: `cctrack`, single binary script, output is a table or `--json`
- ✅ Open source: MIT
- ✅ Built for agents: reads Claude Code's own telemetry format; nothing else uses these files in this way
- ✅ Single-file Python, stdlib-only (no pip dependencies)

### Sample output

```
$ cctrack --days 7
PROJECT                                COST USD    IN tok     OUT tok    CACHE-R     CACHE-W
-------------------------------------  --------    ------     -------    -------     -------
/Users/panda/Project/ai-memory-reader  $ 41.23       2,141   1,367,884   23,912,663   2,185,484
...
```

### License

MIT