### PR TITLE
add authsome under Agent infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[OneCLI](https://github.com/onecli/onecli)** `⭐ 2.2k` — Open-source credential vault for AI agents; Rust HTTP gateway injects API keys transparently so agents never handle raw secrets. Per-agent scoped tokens, AES-256-GCM encryption at rest. Apache-2.0.
 
+- **[authsome](https://github.com/agentrhq/authsome)** `⭐ 35` — Local credential broker for AI agents; Python CLI with encrypted local vault and a local HTTPS proxy that injects OAuth2 access tokens and API keys at request time. 45 providers bundled (14 OAuth2, 31 API key) including GitHub, Google, OpenAI, Linear, Slack, Notion, Resend, Stripe. Browser PKCE / device code / API key flows, background token refresh, no SaaS dependency. MIT.
+
 - **[Claude Code Tools](https://github.com/pchalasani/claude-code-tools)** `⭐ 1.8k` — Utilities around Claude Code workflows (automation helpers, helpers for common tasks).
 
 - **[Coasts](https://github.com/coast-guard/coasts)** `⭐ 389` — Containerized host orchestration for git worktrees; isolates ports, networks, and services per environment using DinD/Sysbox/Podman. MIT.


### PR DESCRIPTION
hey, opening this to add authsome under Harnesses & orchestration → Agent infrastructure.

authsome is a local credential broker for AI agents. log in once via OAuth2 or API key, the encrypted vault sits under ~/.authsome, and a local HTTPS proxy injects credentials at request time so the agent never sees raw secrets. 45 providers bundled (14 OAuth2, 31 API key) including github, google, openai, linear, slack, notion, resend, stripe.

slotted right next to OneCLI since they're direct category peers (both credential vaults that intercept outbound agent requests). different stack (authsome is Python, OneCLI is Rust) and different threat model (authsome is local-first single-user, OneCLI has per-agent scoping for multi-agent fleets). they complement well — happy to reword the entry if you prefer different framing.

works across Claude Code, Codex, Cursor, OpenCode, Hermes, Aider, Pi (anywhere an agent shells out to an authenticated API). integration docs at https://authsome.ai/docs/integrations/agents/index.

repo: https://github.com/agentrhq/authsome
website: https://authsome.ai
license: MIT