### PR TITLE
Add Cadence to Orchestrators & autonomous loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,8 @@ Multi-agent coordination, swarm patterns, and autonomous execution loops. Sorted
 
 - **[agx](https://github.com/ramarlina/agx)** `⭐ 21` — Checkpoint-based execution engine for AI coding agents; durable Wake→Work→Sleep loops that resume instantly across sessions. Supports Claude Code, Codex CLI, Gemini CLI, and Ollama. CLI + web dashboard + macOS app.
 
+- **[Cadence](https://github.com/axledbetter/cadence)** `⭐ 8` — Autonomous Claude Code dev pipeline (brainstorm → spec → plan → implement → migrate → validate → PR → review → bugbot). Multi-model role split (Claude writes, Codex reviews, bugbot triages), risk-tiered review depth, concurrent multi-PR dispatch, 16+ providers, user-type profiles. Every phase a rewireable Claude Code skill. MIT.
+
 - **[Galley](https://github.com/shinpr/galley)** `⭐ 7` — Local-first runtime for supervised AI coding tasks: isolated git worktrees, supervisor review against acceptance criteria, retry/escalate loops, on-disk run evidence, and PR handoff. Supports Codex CLI and Claude Code. Go, MIT.
 
 - **[Relay](https://github.com/jcast90/relay)** `⭐ 4` — Local-first orchestrator that runs inside your existing Claude or Codex CLI via MCP; classifies a request, decomposes it into tickets with a dependency DAG, dispatches across one or more repos, and supervises with live PR tracking + approval gates. CLI, TUI (ratatui), and GUI (Tauri) dashboards share `~/.relay/` state. MIT.


### PR DESCRIPTION
Adds **Cadence** (`@delegance/cadence`), an MIT-licensed CLI that runs Claude Code through an autonomous dev pipeline: brainstorm → spec → plan → implement → migrate → validate → PR → review → bugbot. The pipeline ships itself (every release is shipped by Cadence; commit history and Codex reviews preserved on the repo).

Why it fits this list: Cadence is a CLI-only autonomous loop orchestrator that drives Claude Code through a full spec-to-merge pipeline — directly in scope of "Orchestrators & autonomous loops."

Key features:
- Multi-model role split (Claude writes code, Codex reviews diff, Cursor bugbot triages PR comments)
- Risk-tiered review depth (1/2/3 sequential Codex passes per spec risk frontmatter; auto-escalated by keyword for auth/billing/secrets/migrations/RLS/IAM)
- Concurrent multi-PR dispatch in worktree-isolated branches
- 16+ provider adapters (Anthropic, OpenAI, Google, Groq, Ollama, AWS Bedrock, Azure OpenAI, Cohere, Mistral, plus OpenAI-compatible: Together, Fireworks, OpenRouter, Perplexity, DeepInfra)
- User-type profiles (solo / small-team / enterprise / oss-maintainer / learning)
- Local CLI, free, MIT

Inserted in star order (8 stars, between agx ⭐ 21 and Galley ⭐ 7).

Links:
- npm: https://www.npmjs.com/package/@delegance/cadence
- repo: https://github.com/axledbetter/cadence