### PR TITLE
Add A3M Router (#1 on RouterArena) to Agent infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[claude-code-router](https://github.com/musistudio/claude-code-router)** `⭐ 34.4k` — Use Claude Code as a foundation while routing to alternative providers/endpoints.
 
+- **[A3M Router](https://github.com/Das-rebel/a3m-router)** `⭐ 5` — 🥇 #1 on RouterArena. Open-source LLM router with parallel multi-LLM execution across 47+ providers, semantic cache, budget enforcement, and circuit breakers. `npm i -g adaptive-memory-multi-model-router`. MIT.
+
 - **[agent-browser](https://github.com/vercel-labs/agent-browser)** `⭐ 34.2k` — Headless browser automation CLI for agents (useful as a tool plugin for coding agents).
 
 - **[NemoClaw](https://github.com/NVIDIA/NemoClaw)** `⭐ 20.6k` `[NVIDIA]` — CLI tool for securely provisioning and managing sandboxed OpenClaw agent environments; enforces network, filesystem, and process-level security policies via OpenShell runtime. Apache-2.0.


### PR DESCRIPTION
## What's Added

A3M Router in the **Agent infrastructure** section, alongside claude-code-router.

### Why A3M belongs here
- **LLM router for CLI agents** — routes queries to the cheapest capable model across 47+ providers
- **🥇 #1 on RouterArena** (76.43) — the official standardized benchmark for LLM routers
- **Cheapest at $0.047/1K queries** — 4x cheaper than nearest competitor
- **`npx a3m-router route "your query"`** — drop-in for any CLI agent that needs model routing
- **Open-source, 19.5KB, zero ML deps**

Benchmark: https://github.com/RouteWorks/RouterArena/pull/113
GitHub: https://github.com/Das-rebel/a3m-router