### PR TITLE
Add driftless to Orchestrators & autonomous loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,8 @@ Multi-agent coordination, swarm patterns, and autonomous execution loops. Sorted
 
 - **[sage](https://github.com/youwangd/SageCLI)** `⭐ 3` — Pure bash agent orchestrator (zero frameworks) with runtime-agnostic support (Claude Code, Cline, Codex, Gemini CLI, ACP), wave-based plan execution, git worktree isolation, MCP integration, skills system, headless CI mode, and 295 bats tests. MIT.
 
+- **[driftless](https://github.com/mizan0515/driftless)** `⭐ 0` — Non-developer-operable overnight loop driving both Claude Code and Codex from one source of truth; surveys issues, runs parallel workers, self-recovers, and opens/merges PRs behind human-only gates. Repo-local isolated home (never touches host-global config), containment + mirror-parity gates, exhaustion-ledger so "done" can't hide unfinished work. MIT.
+
 ### Agent infrastructure
 
 Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by GitHub stars.


### PR DESCRIPTION
Adds **driftless** to *Orchestrators & autonomous loops* (placed last, ⭐ 0 — day-one project, sorted per the star convention).

It fits the category: an autonomous "keep running until done" loop that drives **both Claude Code and Codex** from one source of truth — surveys open issues, runs parallel workers, self-recovers, and opens/merges PRs behind human-only gates. It is non-developer-operable (you give a goal in plain language) and runs in a repo-local isolated home (`CLAUDE_CONFIG_DIR`/`CODEX_HOME` inside the repo) so it never touches host-global config. Containment + mirror-parity gates and an exhaustion-ledger keep "done" honest.

- CLI requirement: yes — runs the Claude Code / Codex CLIs in a terminal, isolated per-repo.
- Repo: https://github.com/mizan0515/driftless · MIT · CI green (Windows + Linux).

Thanks for curating this list!