### PR TITLE
feat: add CoderPlan — unified LLM API gateway for CLI coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 - **[agent-browser](https://github.com/vercel-labs/agent-browser)** `⭐ 34.9k` — Headless browser automation CLI for agents (useful as a tool plugin for coding agents).
 
 - **[claude-code-router](https://github.com/musistudio/claude-code-router)** `⭐ 34.6k` — Use Claude Code as a foundation while routing to alternative providers/endpoints.
+- **[CoderPlan](https://coderplan.ai/)** — Unified LLM API gateway for CLI coding agents. Claude, OpenAI, and Gemini models with per-usage billing; one-line config for Claude Code, Codex CLI, and Gemini CLI. Supports Alipay/WeChat Pay.
 
 - **[NemoClaw](https://github.com/NVIDIA/NemoClaw)** `⭐ 20.8k` `[NVIDIA]` — CLI tool for securely provisioning and managing sandboxed OpenClaw agent environments; enforces network, filesystem, and process-level security policies via OpenShell runtime. Apache-2.0.
 


### PR DESCRIPTION
## Summary
Add [CoderPlan](https://coderplan.ai/) to the **Agent infrastructure** section.

CoderPlan is a unified LLM API gateway designed for CLI coding agents:
- Single API endpoint for Claude, OpenAI, and Gemini models
- Per-usage billing with transparent pricing
- One-line config for Claude Code, Codex CLI, and Gemini CLI
- Alipay/WeChat Pay support (optimized for Chinese developers)

## Placement
Added after `claude-code-router` since both serve as routing/gateway infrastructure for CLI coding agents — claude-code-router routes the agent itself, while CoderPlan provides the API endpoint the agent calls.

## Checklist
- [x] Format matches existing entries
- [x] Placed in appropriate section (Agent infrastructure)
- [x] Description is factual and objective
- [x] Disclosure: I am a CoderPlan team member