### PR TITLE
Add DvalinCode to Open Source coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ Forkable, extensible, and community-driven. Sorted by GitHub stars. Provider tag
 
 - **[CLAII](https://github.com/agencyswarm/CLAII)** `⭐ 2` — CLI-first AI coding agent with multi-agent orchestration, MCP toolchains, and memory-persistent refactors.
 
+- **[DvalinCode](https://github.com/arthurpanhku/dvalincode)** `⭐ 1` — Provider-neutral coding agent with three modes (Chat/Cowork/Code), inline diff approval, built-in Web GUI launched from a single binary. Works with any OpenAI-compatible endpoint (DeepSeek, OpenAI, Claude via OpenRouter, Groq, Ollama); macOS shell sandbox via `sandbox-exec`; `.dvalincodeignore` for sensitive files; `AGENTS.md` project memory. MIT.
+
 ### OpenClaw ecosystem
 
 Projects built on, forked from, or inspired by [OpenClaw](https://github.com/openclaw/openclaw) — the open-source personal AI assistant. Sorted by GitHub stars.


### PR DESCRIPTION
Adds [DvalinCode](https://github.com/arthurpanhku/dvalincode) to **Terminal-native coding agents > Open Source**.

DvalinCode is a provider-neutral AI coding agent. The terminal binary auto-launches a built-in Web GUI in your browser. Three distinct modes:

- **Chat** — read-only Q&A with one-click prompt templates
- **Cowork** — plan-then-execute with per-write approval (inline red/green diff)
- **Code** — autonomous agent with full tool access

Key features:
- Works with any OpenAI-compatible endpoint — DeepSeek, OpenAI, Claude via OpenRouter, Groq, Ollama, custom
- macOS shell sandbox via `sandbox-exec` (denies network, restricts writes to cwd + /tmp)
- `.dvalincodeignore` (gitignore-style) blocks read of sensitive files
- `AGENTS.md` auto-injected as persistent project memory
- Inline diff viewer, `@` file refs, `/` slash commands, Git awareness, multi-profile config, live token+cost counter

Single-binary release for macOS / Windows / Linux. MIT licensed. Recently launched at v0.3.0 — happy to add as the project grows.

Thanks for maintaining this list!