### PR TITLE
Add OpenCode Mobile to Agent infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[linear-cli](https://github.com/phnx-labs/linear-cli)** `⭐ 1` — Single-file Python CLI for Linear (the issue tracker), zero dependencies. Designed for use as a subagent tool by Claude Code, Codex, Gemini, or Cursor; ships a SKILL.md for drop-in Claude Code integration. MIT.
 
+- **[OpenCode Mobile](https://github.com/dzianisv/opencode-mobile)** `⭐ 1` — Open-source Android client for the [OpenCode](https://github.com/anomalyco/opencode) coding agent; drive AI coding sessions from your phone against your own self-hosted opencode server over Tailscale/tunnel/LAN, BYOK. Lets you check on and steer running agents while away from the desk. On F-Droid. MIT.
+
 ---
 
 ## Contributing


### PR DESCRIPTION
Adds **OpenCode Mobile** to the Agent infrastructure section.

OpenCode Mobile is a free, MIT-licensed, open-source Android client for the [OpenCode](https://github.com/anomalyco/opencode) coding agent. It connects your phone to your own self-hosted opencode server over Tailscale / tunnel / LAN (bring-your-own AI keys), so you can start, monitor, and steer AI coding sessions while away from the desk — the same remote-control niche as the existing Untether (Telegram bridge) and CliDeck (phone dashboard) entries.

- Repo: https://github.com/dzianisv/opencode-mobile (MIT)
- Available on F-Droid; APK on GitHub Releases.
- Active project.

Placed at the bottom of the **Agent infrastructure** section alongside the other 1-star entries (the section is sorted by stars). Entry follows the required format: name + link, star count, 1–2 line description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)