### PR TITLE
Add grite

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[OSOP](https://github.com/Archie0125/osop-agent-rules)** `⭐ 1` — Universal workflow logging protocol for CLI coding agents; produces `.osop` workflow definitions and `.osoplog.yaml` execution records. Supports Claude Code, Codex, Cursor, Windsurf, Aider, Cline, Roo Code, Devin, and OpenClaw. Includes a [visual editor](https://osop-editor.vercel.app) and [spec](https://github.com/Archie0125/osop-spec).
 
+- **[grite](https://github.com/neul-labs/grite)** `⭐ 6` — Git-backed issue tracker with CRDT merging for AI coding agents. Issues live as an append-only event log in `refs/grite/wal`, sync via `git push`/`fetch`, and converge deterministically across agents — no server, no database, no merge conflicts. Stable `--json` output and a `grite install-skill` command for Claude Code. MIT.
+
 - **[claude-northstar](https://github.com/Nisarg38/claude-northstar)** `⭐ 1` — Transforms CLI agents from task executors into autonomous project partners.
 
 - **[linear-cli](https://github.com/phnx-labs/linear-cli)** `⭐ 1` — Single-file Python CLI for Linear (the issue tracker), zero dependencies. Designed for use as a subagent tool by Claude Code, Codex, Gemini, or Cursor; ships a SKILL.md for drop-in Claude Code integration. MIT.


### PR DESCRIPTION
Adds grite (https://github.com/neul-labs/grite) — a git-backed, repo-local issue tracker with CRDT-based conflict-free merging, designed for AI coding agents. Issues are stored as an append-only event log in `refs/grite/wal` and sync via `git push`/`fetch`, requiring no server or database. Stable `--json` output and a `grite install-skill` command make it scriptable from agents like Claude Code. MIT licensed.

Entry placed in the "Agent infrastructure" section alongside `Wit`, `AgentPlane`, and other agent-coordination tools.