### PR TITLE
Add San — Go terminal-native AI agent runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ Forkable, extensible, and community-driven. Sorted by GitHub stars. Provider tag
 
 - **[QQCode](https://github.com/qnguyen3/qqcode)** `⭐ 51` — Lightweight CLI coding agent in Rust focused on speed, determinism, and developer control; supports skills.
 
+- **[San](https://github.com/genai-io/san)** `⭐ 39` — Go terminal-native runtime for specialized AI agents; provider-agnostic (Anthropic, OpenAI, Google, DeepSeek, Moonshot, Qwen, MiniMax, GLM), runs Claude Code skills/plugins/MCP unmodified, swappable search backends, custom personas, sandboxed subagents, lifecycle hooks, and a self-evolving memory loop. Single ~12 MB binary, zero runtime deps. Apache-2.0.
+
 - **[Smelt](https://github.com/leonardcser/smelt)** `⭐ 21` — Rust TUI coding agent; multi-provider (Anthropic, OpenAI, Ollama, GitHub Copilot, any OpenAI-compatible endpoint), four modes (Normal/Plan/Apply/Yolo), granular permission system, parallel subagents, vim keybindings, and headless scriptable mode. MIT.
 
 - **[Binharic](https://github.com/CogitatorTech/binharic-cli)** `⭐ 16` — A multi-provider "tech-priest persona" coding agent CLI (stylized, tool-using).


### PR DESCRIPTION
Adds **[San](https://github.com/genai-io/san)** to the Open Source terminal-native coding agents section.

Checklist against CONTRIBUTING:
- ✅ Has a CLI / terminal interface (terminal-native).
- ✅ Autonomously reads/writes code and runs commands (tool-using agent with permission modes).
- ✅ Link points to an active, valid project (latest release v2.0.1, Apache-2.0).
- ✅ Inserted in star-sorted order (45★, placed between QQCode 51★ and Smelt 21★).
- ✅ Single item, name + link + star count + one-line description + license.

San is a Go runtime for specialized AI agents: provider-agnostic (Anthropic, OpenAI, Google, DeepSeek, Moonshot, Qwen, MiniMax, GLM), runs Claude Code skills/plugins/MCP unmodified, with swappable search backends, custom personas, sandboxed subagents, lifecycle hooks, and a self-evolving memory loop. Ships as a single ~12 MB binary with zero runtime dependencies.