### PR TITLE
Add OMK to Orchestrators & autonomous loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,8 @@ Multi-agent coordination, swarm patterns, and autonomous execution loops. Sorted
 
 - **[Aeon](https://github.com/aaronjmars/aeon)** `⭐ 270` — Autonomous agent framework that runs unattended on GitHub Actions; orchestrates Claude Code across 90+ skills (research, dev, crypto, productivity) on cron or reactive triggers, with quality scoring (1–5 via Haiku), persistent memory, and a self-healing loop. MCP + A2A integrations. MIT.
 
+- **[OMK](https://github.com/dmae97/open-multi-agent-kit)** `⭐ 83` — Provider-neutral CLI control plane for coding agents: routes runtimes, scopes MCP, runs DAG workers, and verifies evidence before completion. MIT.
+
 - **[Bernstein](https://github.com/chernistry/bernstein)** `⭐ 263` — Deterministic Python orchestrator — spawns parallel AI coding agents (Claude Code, Codex CLI, Gemini CLI), verifies with tests, auto-commits.
 
 - **[wreckit](https://github.com/mikehostetler/wreckit)** `⭐ 126` — Apply the Ralph Wiggum Loop pattern across your roadmap for autonomous agent execution.


### PR DESCRIPTION
## What

[OMK](https://github.com/dmae97/open-multi-agent-kit) is a provider-neutral CLI control plane for coding agents. It routes agent runtimes, scopes MCP tools, runs DAG-based workers, verifies evidence, and preserves replayable run artifacts.

## Why it fits

- CLI-native agent orchestration tool
- Multi-agent DAG coordination with evidence gates
- MCP-scoped tool injection per run
- MIT licensed, 83 GitHub stars

## Entry

```md
- **[OMK](https://github.com/dmae97/open-multi-agent-kit)** `⭐ 83` — Provider-neutral CLI control plane for coding agents: routes runtimes, scopes MCP, runs DAG workers, and verifies evidence before completion. MIT.
```

## Where

Orchestrators & autonomous loops section.