### PR TITLE
Add Loki Mode under Orchestrators and autonomous loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,8 @@ Multi-agent coordination, swarm patterns, and autonomous execution loops. Sorted
 
 - **[loom](https://github.com/ghuntley/loom)** `⭐ 1.3k` — Infrastructure enabling autonomous loops to evolve products via multi-agent coordination.
 
+- **[Loki Mode](https://github.com/asklokesh/loki-mode)** `⭐ 980` — Spec-to-product autonomous loop with a built-in verification gate: a reason/act/reflect/verify closure plus a blind-review completion council that can veto "done", so it will not mark work complete until the evidence passes. Brownfield healing (`loki heal`), local-first BYO-keys, 26-tool MCP server, reads AGENTS.md. Source-available (BUSL-1.1).
+
 - **[Bernstein](https://github.com/chernistry/bernstein)** `⭐ 559` — Deterministic Python orchestrator — spawns parallel AI coding agents (Claude Code, Codex CLI, Gemini CLI), verifies with tests, auto-commits.
 
 - **[Aeon](https://github.com/aaronjmars/aeon)** `⭐ 492` — Autonomous agent framework that runs unattended on GitHub Actions; orchestrates Claude Code across 90+ skills (research, dev, crypto, productivity) on cron or reactive triggers, with quality scoring (1–5 via Haiku), persistent memory, and a self-healing loop. MCP + A2A integrations. MIT.


### PR DESCRIPTION
Adds Loki Mode to the "Orchestrators & autonomous loops" section, placed by star count (971) between loom (1.3k) and Bernstein (559), matching the section's "Sorted by GitHub stars" convention. Entry uses the section's star-badge + separator format to stay consistent with neighboring entries.

What it is: a source-available (BUSL-1.1), CLI-first autonomous coding agent that takes a spec (PRD, GitHub issue, OpenAPI doc, or a one-line brief) toward a deployed product.

Why it fits the section and the inclusion criteria:
- CLI / terminal interface: `loki start ./prd.md`, `loki heal <path>`, etc.
- Reads/writes code and runs commands autonomously via a reason/act/reflect/verify loop.
- Live, actively maintained project (current release v7.27.0).

What makes it distinct from existing entries: an explicit completion-verification gate. Most agents end a task on the model's self-report. Loki runs a blind-review completion council plus an evidence gate that can veto "done", so it keeps working (or asks for input) until the evidence is actually there.

Other specifics: brownfield/legacy healing via `loki heal`; local-first with your own API keys (no data egress); ships a 26-tool MCP server; reads AGENTS.md at the repo root. Provider-agnostic (Claude Code, OpenAI Codex CLI, Cline, Aider).

Reproducible benchmark (available if useful, not led with): 98.78% on HumanEval (162/164), reproducible from the repo via `benchmarks/run-benchmarks.sh humaneval --execute --loki`.

Checked for duplicates: Loki Mode is not currently listed.
