### PR TITLE
Add clu

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[linear-cli](https://github.com/phnx-labs/linear-cli)** `⭐ 1` — Single-file Python CLI for Linear (the issue tracker), zero dependencies. Designed for use as a subagent tool by Claude Code, Codex, Gemini, or Cursor; ships a SKILL.md for drop-in Claude Code integration. MIT.
 
+- **[clu](https://github.com/arjia-labs/clu)** — Codified Likeness Utility: a SQLite-backed issue tracker for coordinating fleets of AI coding agents. Atomic task claim, dependency graphs, workflows & checkpoints, and an audit log. CLI-native with clean `--json` output, built to be driven by agents. Go.
+
 ---
 
 ## Contributing


### PR DESCRIPTION
Adds **clu** (Codified Likeness Utility) to the **Agent infrastructure** section.

clu is a Go, CLI-native, SQLite-backed issue tracker for coordinating fleets of AI coding agents. It provides atomic task claim, dependency graphs, workflows & checkpoints, and an audit log, with clean `--json` output designed to be driven by agents.

It fits this list on the orchestration/infrastructure angle: rather than being a coding agent itself, it coordinates fleets of them. This sits alongside existing infrastructure entries such as linear-cli (an agent-driven issue-tracker CLI), Wit (multi-agent coordination), and AgentManager (managing multiple agent runs).

Repo: https://github.com/arjia-labs/clu

I placed it in Agent infrastructure with no star badge; the update-stars CI job will populate and re-sort it.