### PR TITLE
Add Project Tiny Context Harness to agent infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[linear-cli](https://github.com/phnx-labs/linear-cli)** `⭐ 1` — Single-file Python CLI for Linear (the issue tracker), zero dependencies. Designed for use as a subagent tool by Claude Code, Codex, Gemini, or Cursor; ships a SKILL.md for drop-in Claude Code integration. MIT.
 
+- **[Project Tiny Context Harness](https://github.com/Seven128/project-tiny-context-harness)** `⭐ 0` — Minimal repo-native project memory for CLI coding agents. Installs `AGENTS.md`, `project_context/**`, role Skills, and a `validate-context` gate so Codex, Claude Code, Cursor, Gemini CLI, OpenCode, and similar agents can recover project intent, boundaries, and validation paths across fresh sessions. MIT.
+
 ---
 
 ## Contributing


### PR DESCRIPTION
Adds Project Tiny Context Harness under Agent infrastructure.

It fits this list as a small CLI-distributed harness for coding-agent recovery: repo-local AGENTS.md guidance, project_context/** files, role Skills, and validate-context checks help fresh Codex, Claude Code, Cursor, Gemini CLI, OpenCode, and similar sessions recover project intent and validation paths.
