### PR TITLE
Add handoff to session managers & parallel runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ Tools for running and managing multiple agent sessions side-by-side. Sorted by G
 
 - **[PATAPIM](https://patapim.ai)** — Terminal IDE with a 9-terminal grid for running multiple CLI coding agents simultaneously; features AI state detection, built-in Whisper voice dictation, LAN remote access, and an embedded MCP browser. Built with Electron and node-pty. Freemium.
 
-- **[handoff](https://github.com/dazuiba/handoff)** `⭐ 1` — CLI proxy that dispatches coding tasks to configurable AI backends (Anthropic-compatible endpoints and Codex). Invoke via Claude Code skills (`/handoff-ds`, `/handoff-codex`, `/handoff-opus`) or Codex subagents. Python, `uv tool install handoff-cli`.
+- **[handoff](https://github.com/dazuiba/handoff)** `⭐ 1` — Let your coding agents work together. Delegate tasks to DeepSeek right inside your Claude Code or Codex sessions. Python, `uv tool install handoff-cli`.
 
 ### Orchestrators & autonomous loops
 

--- a/README.md
+++ b/README.md
@@ -281,6 +281,8 @@ Tools for running and managing multiple agent sessions side-by-side. Sorted by G
 
 - **[PATAPIM](https://patapim.ai)** — Terminal IDE with a 9-terminal grid for running multiple CLI coding agents simultaneously; features AI state detection, built-in Whisper voice dictation, LAN remote access, and an embedded MCP browser. Built with Electron and node-pty. Freemium.
 
+- **[handoff](https://github.com/dazuiba/handoff)** `⭐ 1` — CLI proxy that dispatches coding tasks to configurable AI backends (Anthropic-compatible endpoints and Codex). Invoke via Claude Code skills (`/handoff-ds`, `/handoff-codex`, `/handoff-opus`) or Codex subagents. Python, `uv tool install handoff-cli`.
+
 ### Orchestrators & autonomous loops
 
 Multi-agent coordination, swarm patterns, and autonomous execution loops. Sorted by GitHub stars.


### PR DESCRIPTION
Adds [handoff](https://github.com/dazuiba/handoff) under Session managers & parallel runners.

With handoff, your coding agents can finally work together. Delegate tasks to DeepSeek right inside your Claude Code or Codex sessions.

Placed after PATAPIM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)