### PR TITLE
Add Nanocoder to Open Source terminal-native agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ Forkable, extensible, and community-driven. Sorted by GitHub stars. Provider tag
 
 - **[Amazon Q Developer CLI](https://github.com/aws/amazon-q-developer-cli)** `⭐ 2k` `[AWS]` — AWS's agentic terminal chat for building apps, debugging, and DevOps with natural language. Apache-2.0.
 
+- **[Nanocoder](https://github.com/Nano-Collective/nanocoder)** `⭐ 2k` `[Nano Collective]` — Local-first CLI coding agent built by a community collective; bring your own model (Ollama, OpenRouter, or any OpenAI-compatible API), native tool calling with XML fallback, MCP support, and file-based custom commands and tools. MIT.
+
 - **[Neovate Code](https://github.com/neovateai/neovate-code)** `⭐ 1.5k` `[Ant Group]` — Ant Group's CLI agent with plugin system, multi-model/multi-provider support, MCP integrations, and headless automation mode. MIT.
 
 - **[Groq Code CLI](https://github.com/build-with-groq/groq-code-cli)** `⭐ 729` — Customizable, lightweight CLI powered by Groq's ultra-fast inference; extensible tools/commands with multi-model support.


### PR DESCRIPTION
Adds [Nanocoder](https://github.com/Nano-Collective/nanocoder) to Terminal-native coding agents > Open Source.

Nanocoder is a local-first CLI coding agent. Bring your own model (Ollama, OpenRouter, or any OpenAI-compatible API), with native tool calling, an XML fallback, MCP support, and file-based custom commands and tools.

Meets the inclusion criteria:
- Terminal/CLI interface
- Reads/writes code and runs commands
- Valid, active project (2k+ stars, MIT)

Placed in the correct star-sorted position (2k, between Amazon Q Developer CLI and Neovate Code), matching the entry format with star count, provider tag, and license.