### PR TITLE
Add agentic-harness to Agent infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[linear-cli](https://github.com/phnx-labs/linear-cli)** `⭐ 1` — Single-file Python CLI for Linear (the issue tracker), zero dependencies. Designed for use as a subagent tool by Claude Code, Codex, Gemini, or Cursor; ships a SKILL.md for drop-in Claude Code integration. MIT.
 
+- **[agentic-harness](https://github.com/MrBogomips/agentic-harness)** `⭐ 0` — Claude Code plugin (meta-tool) that builds, reviews, and maintains a project's agentic harness — the agents, skills, and orchestrator under `.claude/`. Coordinates with existing spec systems and issue trackers, and can sync a repo-native tracker with Jira/Linear. MIT.
+
 ---
 
 ## Contributing


### PR DESCRIPTION
Proposes adding **agentic-harness** under **Harnesses & orchestration → Agent infrastructure** (placed at the bottom, ⭐ 0, per the star-descending order).

[agentic-harness](https://github.com/MrBogomips/agentic-harness) is an MIT-licensed Claude Code plugin (a meta-tool) that builds, reviews, and maintains a project's agentic harness — the agents, skills, and orchestrator under `.claude/` — coordinating with existing spec-driven-development systems and issue trackers, and optionally syncing a repo-native tracker with Jira/Linear.

**Honest scope note for the maintainer:** agentic-harness runs *inside* Claude Code as a plugin; it is not a standalone terminal binary of its own. I'm proposing it for **Agent infrastructure** (the "extension tools" part of that subsection's scope) rather than the CLI-agent sections, since it's infrastructure that configures and maintains the harness CLI agents work through — alongside existing entries here that are themselves Claude Code plugins/skills (e.g. linear-cli, claude-northstar). If you feel it falls outside the list's "CLI or terminal interface" criterion, no hard feelings closing this — your call.