### PR TITLE
Add A3M Router - parallel multi-LLM execution (#1 on RouterArena)

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[claude-code-router](https://github.com/musistudio/claude-code-router)** `⭐ 35k` — Use Claude Code as a foundation while routing to alternative providers/endpoints.
 
+- **[A3M Router](https://github.com/Das-rebel/a3m-router)** `⭐ 5` — 🥇 #1 on RouterArena. Open-source LLM router with parallel multi-LLM execution across 47+ providers, semantic cache, budget enforcement, and circuit breakers. `npm i -g adaptive-memory-multi-model-router`. MIT.
+
 - **[NemoClaw](https://github.com/NVIDIA/NemoClaw)** `⭐ 21.2k` `[NVIDIA]` — CLI tool for securely provisioning and managing sandboxed OpenClaw agent environments; enforces network, filesystem, and process-level security policies via OpenShell runtime. Apache-2.0.
 
 - **[OpenWork](https://github.com/different-ai/openwork)** `⭐ 16.1k` — Open-source alternative to Claude Cowork for teams; local-first desktop app powered by OpenCode with one-click setup. MIT.


### PR DESCRIPTION
A3M Router: 🥇 #1 on RouterArena for robustness. Parallel multi-LLM execution across 47+ providers with semantic cache, budget enforcement, and circuit breakers.

- MIT license, TypeScript
- npm: `npm i -g adaptive-memory-multi-model-router`
- 20K+ npm downloads

Fixed the conflicting PR by rebasing against latest main.