### PR TITLE
Add Zap — skill-first Rust TUI coding agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ Forkable, extensible, and community-driven. Sorted by GitHub stars. Provider tag
 
 - **[Smelt](https://github.com/leonardcser/smelt)** `⭐ 23` — Rust TUI coding agent; multi-provider (Anthropic, OpenAI, Ollama, GitHub Copilot, any OpenAI-compatible endpoint), four modes (Normal/Plan/Apply/Yolo), granular permission system, parallel subagents, vim keybindings, and headless scriptable mode. MIT.
 
+- **[Zap](https://github.com/zap-coding-agent/zap-coding-agent)** `⭐ 18` — Skill-first Rust TUI coding agent that injects only the context your task needs — no system prompt bloat. Single binary, no runtime. Supports Claude, Gemini, OpenAI, and local models via LM Studio; code-indexed via SQLite for fast symbol lookup; MCP support. MIT.
+
 - **[Binharic](https://github.com/CogitatorTech/binharic-cli)** `⭐ 16` — A multi-provider "tech-priest persona" coding agent CLI (stylized, tool-using).
 
 - **[Darce](https://github.com/AmerSarhan/darce-cli)** `⭐ 4` — Ultralight (14 kB) multi-model CLI agent built with Ink; 7 tools, smart model routing across providers, streaming, session resume, and slash commands. MIT.


### PR DESCRIPTION
## What

Adds [Zap](https://github.com/zap-coding-agent/zap-coding-agent) to the Open Source section, sorted by star count (18 ⭐, between Smelt at 23 and Binharic at 16).

## Entry

```
- **[Zap](https://github.com/zap-coding-agent/zap-coding-agent)** `⭐ 18` — Skill-first Rust TUI coding agent that injects only the context your task needs — no system prompt bloat. Single binary, no runtime. Supports Claude, Gemini, OpenAI, and local models via LM Studio; code-indexed via SQLite for fast symbol lookup; MCP support. MIT.
```

## Why it fits

- Terminal-native TUI (Ratatui), reads/edits files, runs shell commands autonomously ✓
- MIT license, active project ✓
- Distinct angle among Rust agents: skill-first context injection (no always-on system prompt), SQLite code index for symbol lookup, LM Studio/local model support — differentiates from Smelt, g3, picocode, QQCode, and Crab Code already in the list