### PR TITLE
Add Clave (macOS app for running coding-agent CLIs in parallel)

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,8 @@ Tools for running and managing multiple agent sessions side-by-side. Sorted by G
 
 - **[CliDeck](https://github.com/rustykuntz/clideck)** `⭐ 110` — WhatsApp-like browser dashboard for managing multiple CLI coding agents (Claude Code, Codex, Gemini CLI, OpenCode) with live status detection, session resume, autopilot routing, and full control from a phone while away. MIT.
 
+- **[Clave](https://github.com/codika-io/clave)** `⭐ 25` — Native macOS app for running multiple AI coding-agent CLIs (Claude Code, Gemini CLI, Codex) in parallel — split/grid terminal layouts, per-project session groups, a built-in git panel, and remote sessions over SSH. Fully local, no account. Electron. MIT.
+
 - **[agent-deck](https://github.com/asheshgoplani/agent-deck)** `⭐ 15` — Terminal session manager for AI coding agents — one TUI for Claude, Gemini, OpenCode, Codex, and more. Worktree-aware, MCP integration, 8+ contributors. MIT.
 
 - **[multi-agent-workflow-kit](https://github.com/laris-co/multi-agent-workflow-kit)** `⭐ 10` — Orchestrate parallel AI agents in isolated git worktrees with shared tmux visibility.


### PR DESCRIPTION
Adds **Clave** to *Harnesses & orchestration → Session managers & parallel runners*.

- **Repo:** https://github.com/codika-io/clave
- **What it is:** Native macOS desktop app for running multiple AI coding-agent CLIs (Claude Code, Gemini CLI, Codex) in parallel, with split/grid terminal layouts, per-project session groups, a built-in git panel, and remote sessions over SSH.
- **License:** MIT · **Active:** yes (latest release v1.56.1, June 2026)

Placed in star-descending order between CliDeck (⭐110) and agent-deck (⭐15). Single entry, follows the existing format.