### PR TITLE
Add postmortemthis (parallel multi-agent review runner)

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,8 @@ Tools for running and managing multiple agent sessions side-by-side. Sorted by G
 
 - **[PATAPIM](https://patapim.ai)** — Terminal IDE with a 9-terminal grid for running multiple CLI coding agents simultaneously; features AI state detection, built-in Whisper voice dictation, LAN remote access, and an embedded MCP browser. Built with Electron and node-pty. Freemium.
 
+- **[postmortemthis](https://github.com/Softeria/postmortemthis)** `⭐ 0` — Runs every coding-agent CLI you have (Claude Code, Codex, Gemini, Qwen, Vibe) in parallel and read-only over your diff, then synthesizes their reviews into one ship / no-ship verdict. A cross-model second opinion before you ship. MIT.
+
 ### Orchestrators & autonomous loops
 
 Multi-agent coordination, swarm patterns, and autonomous execution loops. Sorted by GitHub stars.


### PR DESCRIPTION
Adds **postmortemthis** to Session managers & parallel runners.

Open-source (MIT) CLI that runs every coding-agent CLI you have (Claude Code, Codex, Gemini, Qwen, Vibe) in parallel and read-only over your diff, then synthesizes their reviews into one ship / no-ship verdict. It runs the agents' native CLIs (own tools and models), holds no keys, and changes nothing. Meets the criteria: terminal interface, runs the agent CLIs, active MIT repo.

Repo: https://github.com/Softeria/postmortemthis

Disclosure: I'm the author.