### PR TITLE
Add rein to Agent infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,7 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 - **[claude-northstar](https://github.com/Nisarg38/claude-northstar)** `⭐ 1` — Transforms CLI agents from task executors into autonomous project partners.
 
 - **[linear-cli](https://github.com/phnx-labs/linear-cli)** `⭐ 1` — Single-file Python CLI for Linear (the issue tracker), zero dependencies. Designed for use as a subagent tool by Claude Code, Codex, Gemini, or Cursor; ships a SKILL.md for drop-in Claude Code integration. MIT.
+- **[rein](https://github.com/SalzDevs/rein)** `⭐ 0` — Go library + CLI that gives AI coding agents reliable shell execution: process group isolation (no leaked children on agent crash), graceful SIGTERM→SIGKILL shutdown, PTY allocation, idle-timeout detection, and overflow policies for long-running dev commands. Speaks NDJSON over stdio with Python and Node clients; cross-platform (Linux, macOS, Windows non-PTY). Go, MIT.
 
 ---
 


### PR DESCRIPTION
## What

Adds `rein` to the **Agent infrastructure** section.

## Why this section

rein is a Go library + CLI that gives AI coding agents reliable shell execution. The four problems every agent framework has with shell commands:

1. **Leaked child processes** when the agent crashes (`npm run dev` keeps running, holds the port)
2. **SIGKILL with no SIGTERM grace** → database connections dropped, dirty shutdown
3. **PTY allocation** for interactive commands (`vim`, REPLs, anything that needs a TTY)
4. **Idle-timeout detection** → kills processes that stalled on dead TCP

rein gives you all four with one API (`rein.Run` / `rein.Start`), plus an overflow policy (Block / DropNewest / DropOldest) for the output channel.

The CLI speaks NDJSON over stdio, so any agent framework (Claude Code, Codex, OpenCode, Goose, Aider) can drive it. Python and Node clients are in the repo.

## How it compares to existing entries in this section

- **agent-lsp** (Go, MIT) — type-aware language intelligence for agents. Same shape (Go library that agents use), MIT licensed.
- **agenttrace** (Go) — local-first session log inspector.
- **gate4agent** (Rust, MIT) — "Universal transport library for CLI AI agents. Pipe/NDJSON, PTY, and ACP (JSON-RPC 2.0) modes." — rein is essentially gate4agent's mirror in Go.

## Quality

- A+ on Go Report Card
- Race-clean: `go test -race -count=1 ./...` passes
- CI green on Linux, macOS, Windows
- v0.1.0 tagged and released
- 41 commits, MIT licensed
- Honest about Windows limitations (ConPTY is on the v0.2 roadmap)

## Checklist

- [x] CLI/terminal interface (yes, `rein` binary + library)
- [x] Can be used by agents to run commands (yes, that's the point)
- [x] Valid, active project (just shipped v0.1.0, actively maintained)
- [x] Placed at the bottom of the section (0 stars, sorted correctly)
- [x] 1-line description following the entry format
- [x] License noted (MIT)