### PR TITLE
Add LoopTroop to Orchestrators & autonomous loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,8 @@ Multi-agent coordination, swarm patterns, and autonomous execution loops. Sorted
 
 - **[agx](https://github.com/ramarlina/agx)** `⭐ 23` — Checkpoint-based execution engine for AI coding agents; durable Wake→Work→Sleep loops that resume instantly across sessions. Supports Claude Code, Codex CLI, Gemini CLI, and Ollama. CLI + web dashboard + macOS app.
 
+- **[LoopTroop](https://github.com/looptroop-ai/LoopTroop)** `⭐ 20` — Local, open-source GUI orchestrator for AI coding agents. An LLM Council plans, atomic "beads" execute in isolated git worktrees, and a "Ralph Loop" retries failures with fresh context to fight context rot. Built on OpenCode. MIT.
+
 - **[Galley](https://github.com/shinpr/galley)** `⭐ 11` — Local-first runtime for supervised AI coding tasks: isolated git worktrees, supervisor review against acceptance criteria, retry/escalate loops, on-disk run evidence, and PR handoff. Supports Codex CLI and Claude Code. Go, MIT.
 
 - **[Relay](https://github.com/jcast90/relay)** `⭐ 4` — Local-first orchestrator that runs inside your existing Claude or Codex CLI via MCP; classifies a request, decomposes it into tickets with a dependency DAG, dispatches across one or more repos, and supervises with live PR tracking + approval gates. CLI, TUI (ratatui), and GUI (Tauri) dashboards share `~/.relay/` state. MIT.


### PR DESCRIPTION
Hi! Adding LoopTroop to the "Orchestrators & autonomous loops" section.

LoopTroop is a local, open-source GUI orchestrator for AI coding agents (MIT, v0.3.0, active). It felt like a natural fit here: an LLM Council (multiple models draft, vote, refine) is multi-agent coordination, and the Ralph Loop (reset the worktree and retry with fresh context on failure) is an autonomous execution loop. It drives the OpenCode CLI agent in isolated git worktrees, similar to how OpenWork (already listed under Agent infrastructure) is a desktop app powered by OpenCode.

Inclusion criteria:
- Interface: it orchestrates the OpenCode CLI agent, which reads/writes code and runs commands autonomously. It's a GUI harness rather than a terminal-native agent, which lines up with the other GUI/desktop harnesses already in this section (vibe-kanban, Cate, Parallel Code, Clave).
- Active project: github.com/looptroop-ai/LoopTroop, latest release v0.3.0 a few days ago, commits within the last day.

Entry placed in star-sorted position (20, between agx at 23 and Galley at 11), following the entry format (bold name + link, star count, one-line description, license). One line only; I left the "Last updated" date and the "90+" count for the star-count updater.

Happy to move it to another section or tweak the wording if you'd prefer.
