### PR TITLE
Add ralph-harness to orchestrators

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,9 @@ Multi-agent coordination, swarm patterns, and autonomous execution loops. Sorted
 
 ### Agent infrastructure
 
+- **[ralph-harness](https://github.com/rxdt/py_ralph_frame)** `new` — Minimal repo-local loop scaffold for Claude Code, Codex CLI, and Gemini CLI. Uses `PROMPT.md`, specs, fresh-context iterations, git hooks, CI verification, and hard iteration/time caps so agents make small gated commits instead of drifting in one long chat. MIT.
+
+
 Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by GitHub stars.
 
 - **[agent-browser](https://github.com/vercel-labs/agent-browser)** `⭐ 36.8k` — Headless browser automation CLI for agents (useful as a tool plugin for coding agents).


### PR DESCRIPTION
Adds `ralph-harness` to **Harnesses & orchestration → Orchestrators & autonomous loops**.

Why it fits:
- Targets terminal-native coding agents: Claude Code, Codex CLI, and Gemini CLI.
- Provides a repo-local guarded loop rather than a hosted orchestrator.
- Uses specs, fresh-context iterations, git hooks, CI gates, and iteration/time caps to keep work small and recoverable.

Trial command:

```sh
uvx --from git+https://github.com/rxdt/py_ralph_frame ralph-harness demo
```

Related candidate issue: #148