### PR TITLE
Add repomon (fleet of AI coding agents across many repos)

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,8 @@ Tools for running and managing multiple agent sessions side-by-side. Sorted by G
 
 - **[tmuxlet](https://github.com/CodefiLabs/tmuxlet)** `⭐ 6` — Rust CLI that runs interactive coding CLIs (Claude, Codex, Gemini, opencode, pi, Cursor) inside tmux and exposes a normalized `claude -p` style blocking interface. Single binary, zero deps. Works against the regular Claude subscription bucket (not the separate Agent SDK credit) by driving interactive Claude Code from the outside.
 
+- **[repomon](https://github.com/AliHamzaAzam/repomon)** `⭐ 2` - Run a fleet of AI coding agents (Claude Code, Codex, Aider) across many repos, branches, and git worktrees from one tmux-backed terminal. Four-zoom TUI (fleet, split, babysit grid, focus), needs-you triage, durable sessions that survive restarts.
+
 - **[PATAPIM](https://patapim.ai)** — Terminal IDE with a 9-terminal grid for running multiple CLI coding agents simultaneously; features AI state detection, built-in Whisper voice dictation, LAN remote access, and an embedded MCP browser. Built with Electron and node-pty. Freemium.
 
 ### Orchestrators & autonomous loops


### PR DESCRIPTION
repomon is an open-source (Apache-2.0) Rust TUI for running many coding agents at once across multiple repos/worktrees, not just one repo. Four zoom levels, durable tmux sessions, needs-you notifications. I'm the author. Happy to adjust placement or wording.