### PR TITLE
Update DvalinCode entry (governance: policy, egress enforcement, audit trail)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Forkable, extensible, and community-driven. Sorted by GitHub stars. Provider tag
 
 - **[Binharic](https://github.com/CogitatorTech/binharic-cli)** `⭐ 16` — A multi-provider "tech-priest persona" coding agent CLI (stylized, tool-using).
 
-- **[DvalinCode](https://github.com/arthurpanhku/dvalincode)** `⭐ 9` — Provider-neutral coding agent with three modes (Chat/Cowork/Code), inline diff approval, built-in Web GUI launched from a single binary. Works with any OpenAI-compatible endpoint (DeepSeek, OpenAI, Claude via OpenRouter, Groq, Ollama); macOS shell sandbox via `sandbox-exec`; `.dvalincodeignore` for sensitive files; `AGENTS.md` project memory. MIT.
+- **[DvalinCode](https://github.com/arthurpanhku/dvalincode)** `⭐ 9` — Provider-neutral, local-first coding agent (Chat/Cowork/Code modes) built for governance: an org policy engine, enforced network egress (per-request checks plus OS-sandboxed subprocesses via `sandbox-exec`/Bubblewrap), and a tamper-evident, hash-chained audit trail. Inline diff approval, durable session journal, built-in Web GUI from a single binary; works with any OpenAI-compatible endpoint (DeepSeek, OpenAI, Claude via OpenRouter, Groq, Ollama). Zero runtime deps. MIT.
 
 - **[Darce](https://github.com/AmerSarhan/darce-cli)** `⭐ 5` — Ultralight (14 kB) multi-model CLI agent built with Ink; 7 tools, smart model routing across providers, streaming, session resume, and slash commands. MIT.
 


### PR DESCRIPTION
Refreshes the existing **DvalinCode** entry under _Terminal-native coding agents → Open Source_ to reflect its current release (v0.8.1). Disclosure: I maintain DvalinCode.

The old description predated the project's governance work. What's new and worth surfacing for this list:

- **Org policy engine** — machine + repo policy, resolved by narrowing (repo can only tighten), enforced at a single tool chokepoint.
- **Enforced network egress** — per-request origin checks for provider calls (`off` / `endpoint-only` / `on`), plus OS-sandboxed subprocesses (macOS `sandbox-exec`, Linux Bubblewrap `--unshare-net`) that fail closed on platforms that can't enforce isolation.
- **Tamper-evident audit trail** — append-only, hash-chained log; `dvalincode trust` reports the install's actual enforcement posture.
- **Durable session journal** — crash recovery + idempotent replay, anchored to the audit chain.

Still provider-neutral (any OpenAI-compatible endpoint), local-first, zero runtime deps, MIT. Star count and sorted position are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)