### PR TITLE
Add cowork-to-code-bridge to Agent infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[Not Human Search](https://github.com/unitedideas/nothumansearch)** `⭐ 6` — Search engine for AI agents that ranks sites by agentic readiness (llms.txt, OpenAPI, MCP, ai-plugin); 8,000+ indexed sites exposed via MCP server, REST API, and full-text search. Lets agents discover and verify external services before wiring them into a repo. MIT.
 
+- **[cowork-to-code-bridge](https://github.com/abhinaykrupa/cowork-to-code-bridge)** `⭐ 6` — Async file-based bridge that lets a sandboxed/cloud agent (Claude Cowork, CrewAI, AutoGen, LlamaIndex) delegate work to Claude Code running on your real macOS/Linux machine. A local daemon picks tasks off a shared bind-mounted directory, runs them through `run_claude.sh` (per-task model routing + budget caps + permission scoping), and returns results — no inbound network, no HTTPS tunnel. Ships a Claude Code skill, MCP audit, and selfcheck. MIT.
+
 - **[pi-builder](https://github.com/arosstale/pi-builder)** `⭐ 5` — TypeScript monorepo that wraps any installed CLI coding agent (Claude Code, Aider, OpenCode, Codex, Gemini CLI, Goose, Plandex, SWE-agent, Crush, gptme) behind a single interface; capability-based routing, health caching, fallback chains, SQLite persistence, and a streaming OrchestratorService. MIT.
 
 - **[OSOP](https://github.com/Archie0125/osop-agent-rules)** `⭐ 2` — Universal workflow logging protocol for CLI coding agents; produces `.osop` workflow definitions and `.osoplog.yaml` execution records. Supports Claude Code, Codex, Cursor, Windsurf, Aider, Cline, Roo Code, Devin, and OpenClaw. Includes a [visual editor](https://osop-editor.vercel.app) and [spec](https://github.com/Archie0125/osop-spec).


### PR DESCRIPTION
Adds **[cowork-to-code-bridge](https://github.com/abhinaykrupa/cowork-to-code-bridge)** to **Harnesses & orchestration → Agent infrastructure**.

It's an async, file-based bridge that lets a sandboxed or cloud-hosted agent (Claude Cowork, CrewAI, AutoGen, LlamaIndex, etc.) delegate work to **Claude Code running on the user's own macOS/Linux machine**. A local daemon picks tasks off a shared bind-mounted directory, runs them through `run_claude.sh` (per-task model routing, budget caps, permission scoping), and returns results — no inbound network and no HTTPS tunnel required.

**Meets the inclusion criteria:**
- ✅ CLI / terminal interface (drives the Claude Code CLI; ships a daemon + allowed-scripts)
- ✅ Reads/writes code and runs commands autonomously
- ✅ Valid, active project (245 passing tests, CI + selfcheck green, MIT)

Placed within the section by GitHub star count (6★), between the 6★ and 5★ entries.