### PR TITLE
Add AgentPipe (cross-vendor adversarial review pipeline)

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,8 @@ Multi-agent coordination, swarm patterns, and autonomous execution loops. Sorted
 
 - **[sage](https://github.com/youwangd/SageCLI)** `⭐ 3` — Pure bash agent orchestrator (zero frameworks) with runtime-agnostic support (Claude Code, Cline, Codex, Gemini CLI, ACP), wave-based plan execution, git worktree isolation, MCP integration, skills system, headless CI mode, and 295 bats tests. MIT.
 
+- **[AgentPipe](https://github.com/Xiaofuziod/agentpipe)** `⭐ 0` — Cross-vendor adversarial review pipeline: one agent writes (Claude), a different vendor reviews (Codex), looping until the reviewer is clean — with deterministic command gates (exit code = verdict) and fail-closed convergence. Rust engine + Tauri desktop GUI. macOS-first. MIT.
+
 ### Agent infrastructure
 
 Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by GitHub stars.


### PR DESCRIPTION
Adds **AgentPipe** to *Harnesses & orchestration → Orchestrators & autonomous loops* (placed at the end, per the star-sorted ordering — it's brand new at 0 stars).

[AgentPipe](https://github.com/Xiaofuziod/agentpipe) is a serial, declarative pipeline (not a parallel swarm): one agent writes (Claude), a *different vendor* reviews (Codex), and the loop repeats until the reviewer is clean. Verify gates can be `by: command` (your own test/build/lint — exit code 0 = goal met), and convergence is fail-closed (a parse failure or hitting the loop max stops for a human rather than passing silently). Rust engine + Tauri desktop GUI; macOS-first; MIT.

Entry follows the section format (name + link + `⭐` + 1–2 line description with distinctive features + license). Thanks for maintaining the list!