### PR TITLE
Add PatchWarden to agent infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,7 +547,7 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[claude-northstar](https://github.com/Nisarg38/claude-northstar)** `⭐ 1` — Transforms CLI agents from task executors into autonomous project partners.
 
-- **[PatchWarden](https://github.com/jiezeng2004-design/PatchWarden)** `⭐ 1` — Local-first MCP safety and verification layer for AI coding agents; adds workspace confinement, command allowlists, scope-violation detection, and auditable task evidence for OpenCode, Codex, and other MCP clients. MIT.
+- **[PatchWarden](https://github.com/jiezeng2004-design/PatchWarden)** `⭐ 2` — Local-first MCP safety and verification layer for AI coding agents; adds workspace confinement, command allowlists, scope-violation detection, and auditable task evidence for OpenCode, Codex, and other MCP clients. MIT.
 
 - **[Hivelore](https://github.com/Doucs91/hivelore)** `⭐ 1` — Deterministic policy gate for agent-written code: a lesson captured via MCP (`mem_tried`) becomes a validated regex/AST/test guard that Git hooks and CI use to refuse any diff reintroducing the documented mistake; briefs any agent with the team's repo-specific rules over MCP. TypeScript CLI, npm (`@hivelore/cli`). Apache-2.0.
 

--- a/README.md
+++ b/README.md
@@ -547,6 +547,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[claude-northstar](https://github.com/Nisarg38/claude-northstar)** `⭐ 1` — Transforms CLI agents from task executors into autonomous project partners.
 
+- **[PatchWarden](https://github.com/jiezeng2004-design/PatchWarden)** `⭐ 1` — Local-first MCP safety and verification layer for AI coding agents; adds workspace confinement, command allowlists, scope-violation detection, and auditable task evidence for OpenCode, Codex, and other MCP clients. MIT.
+
 - **[Hivelore](https://github.com/Doucs91/hivelore)** `⭐ 1` — Deterministic policy gate for agent-written code: a lesson captured via MCP (`mem_tried`) becomes a validated regex/AST/test guard that Git hooks and CI use to refuse any diff reintroducing the documented mistake; briefs any agent with the team's repo-specific rules over MCP. TypeScript CLI, npm (`@hivelore/cli`). Apache-2.0.
 
 - **[agent-trace](https://github.com/ertygiq/agent-trace)** `⭐ 0` — Text-only CLI for extracting filtered transcripts from Claude Code, Codex, and Pi session files; useful for debugging, review, and piping transcripts into other tools. MIT.


### PR DESCRIPTION
## Summary

Adds PatchWarden to the Agent infrastructure section.

I maintain PatchWarden. It is a local-first MCP safety and verification layer for AI coding agents, with workspace confinement, command allowlists, scope-violation detection, and auditable task evidence for OpenCode, Codex, and other MCP clients.

## Checks

- Confirmed PatchWarden currently has 2 GitHub stars and MIT license.
- Confirmed `patchwarden@1.6.2` is published on npm with `latest=1.6.2`.
- Confirmed PatchWarden v1.6.2 GitHub Release is published.
- Checked this repository for existing open PatchWarden PRs/issues before adding the entry.
- Ran `git diff --check`.