### PR TITLE
Add Codex Infinity

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ Forkable, extensible, and community-driven. Sorted by GitHub stars. Provider tag
 
 - **[openHarness](https://github.com/zhijiewong/openharness)** `⭐ 95` — Open-source Claude Code alternative. 78 slash commands, 42 tools, MCP (stdio/HTTP/SSE + OAuth 2.1), hooks, subagents, plan mode. Works with Anthropic/OpenAI/Ollama/llama.cpp/LM Studio. Ships both npm and Python SDK. MIT.
 
+- **[Codex Infinity](https://github.com/lee101/codex-infinity)** `⭐ 84` — Autonomous terminal coding agent (OpenAI Codex CLI fork) adding auto-continuation, parallel multi-agent runs, and CI repair loops.
+
 - **[VibePod](https://github.com/VibePod/vibepod-cli)** `⭐ 81` — Unified CLI for running AI coding agents in isolated Docker containers; zero-config setup, local metrics, HTTP traffic tracking, and an analytics dashboard for side-by-side comparison.
 
 - **[Octomind](https://github.com/Muvon/octomind)** `⭐ 78` — Open-source, model-agnostic AI agent runtime with community tap registry (`developer:rust`, `doctor:blood`, `legal:contracts`), MCP support with runtime self-extension, 13+ providers, and adaptive compression. Written in Rust. Apache-2.0.


### PR DESCRIPTION
Adds Codex Infinity (https://github.com/lee101/codex-infinity, https://codex-infinity.com) to the Open Source terminal-native coding agents. It's an OpenAI Codex CLI fork adding auto-continuation, parallel multi-agent runs, and CI repair loops. Placed in the star-sorted Open Source subsection and matched the entry format.