### PR TITLE
Add ActraDeck (Agent infrastructure)

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[claude-northstar](https://github.com/Nisarg38/claude-northstar)** `⭐ 1` — Transforms CLI agents from task executors into autonomous project partners.
 
+- **[ActraDeck](https://github.com/actradeck/actradeck)** `⭐ 0` — Local-first cockpit for supervising Claude Code and Codex sessions in real time; normalizes both agents into one event timeline with secret redaction before persist, approval gates for destructive ops, and an append-only audit trail. `agentmon` sidecar + web console. Apache-2.0, TypeScript.
+
 ---
 
 ## Contributing


### PR DESCRIPTION
Adds **ActraDeck** to the *Agent infrastructure* section.

ActraDeck is a local-first cockpit that supervises Claude Code and Codex
sessions in real time — normalizing both agents into one event timeline,
redacting secrets before they're persisted, gating destructive operations
behind approvals, and keeping an append-only audit trail. It's
governance/observability infrastructure for coding agents, in the same vein as
agenttrace, AgentSight, and the Agentic Engineering Framework already in this
section.

Inclusion criteria:
- **CLI / terminal interface:** ships the `agentmon` sidecar daemon (CLI); the
  web console is an additional surface, not IDE-only.
- **Active project:** https://github.com/actradeck/actradeck (Apache-2.0, TypeScript).
- **Placement:** sorted by stars — added at the end of the section.

Entry:
- **[ActraDeck](https://github.com/actradeck/actradeck)** `⭐ 0` — Local-first cockpit for supervising Claude Code and Codex sessions in real time; normalizes both agents into one event timeline with secret redaction before persist, approval gates for destructive ops, and an append-only audit trail. `agentmon` sidecar + web console. Apache-2.0, TypeScript.
