### PR TITLE
Add Claudescope to Session managers & parallel runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,8 @@ Tools for running and managing multiple agent sessions side-by-side. Sorted by G
 
 - **[CLITrigger](https://github.com/HyperAITeam/CLITrigger)** `⭐ 8` — Self-hosted web UI for orchestrating Claude Code, Codex, and Gemini CLIs in parallel git worktrees. Features multi-agent discussion mode (architect/developer/reviewer debate before implementation), cross-project Morning Review Queue, scheduled execution with rate-limit auto-recovery, and a built-in Git client. MIT.
 
+- **[Claudescope](https://github.com/vladar107/claudescope)** `⭐ 8` — Local, read-only CLI that serves a web UI to browse, search, and analyze AI coding-agent transcripts across Claude Code, Codex, Junie, pi, opencode, and Copilot CLI — sessions merged by working directory, with full-text search and token-cost analytics. npm, cross-platform. MIT.
+
 - **[tmuxlet](https://github.com/CodefiLabs/tmuxlet)** `⭐ 6` — Rust CLI that runs interactive coding CLIs (Claude, Codex, Gemini, opencode, pi, Cursor) inside tmux and exposes a normalized `claude -p` style blocking interface. Single binary, zero deps. Works against the regular Claude subscription bucket (not the separate Agent SDK credit) by driving interactive Claude Code from the outside.
 
 - **[PATAPIM](https://patapim.ai)** — Terminal IDE with a 9-terminal grid for running multiple CLI coding agents simultaneously; features AI state detection, built-in Whisper voice dictation, LAN remote access, and an embedded MCP browser. Built with Electron and node-pty. Freemium.


### PR DESCRIPTION
Adds **Claudescope** to *Harnesses & orchestration → Session managers & parallel runners*.

[Claudescope](https://github.com/vladar107/claudescope) is a local, read-only CLI (`claudescope start`) that serves a web UI to browse, read, search, and analyze AI coding-agent transcripts across **Claude Code, Codex, Junie, pi, opencode, and Copilot CLI**. Sessions are merged by working directory into one project per cwd; it adds DuckDB full-text search and token-cost analytics. Distributed as a single npm package, MIT-licensed, cross-platform.

It's a close peer to **Agent Sessions** already in this section — a multi-agent session-history viewer. Placed at `⭐ 8` to keep the section's star ordering (right after CLITrigger, before tmuxlet).