### PR TITLE
Add Skill Hub to Agent infrastructure section

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,9 +449,11 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[pi-builder](https://github.com/arosstale/pi-builder)** `⭐ 5` — TypeScript monorepo that wraps any installed CLI coding agent (Claude Code, Aider, OpenCode, Codex, Gemini CLI, Goose, Plandex, SWE-agent, Crush, gptme) behind a single interface; capability-based routing, health caching, fallback chains, SQLite persistence, and a streaming OrchestratorService. MIT.
 
-- **[OSOP](https://github.com/Archie0125/osop-agent-rules)** `⭐ 2` — Universal workflow logging protocol for CLI coding agents; produces `.osop` workflow definitions and `.osoplog.yaml` execution records. Supports Claude Code, Codex, Cursor, Windsurf, Aider, Cline, Roo Code, Devin, and OpenClaw. Includes a [visual editor](https://osop-editor.vercel.app) and [spec](https://github.com/Archie0125/osop-spec).
+|- **[OSOP](https://github.com/Archie0125/osop-agent-rules)** `⭐ 2` — Universal workflow logging protocol for CLI coding agents; produces `.osop` workflow definitions and `.osoplog.yaml` execution records. Supports Claude Code, Codex, Cursor, Windsurf, Aider, Cline, Roo Code, Devin, and OpenClaw. Includes a [visual editor](https://osop-editor.vercel.app) and [spec](https://github.com/Archie0125/osop-spec).
 
-- **[claude-northstar](https://github.com/Nisarg38/claude-northstar)** `⭐ 1` — Transforms CLI agents from task executors into autonomous project partners.
+|- **[Skill Hub](https://github.com/rdone4425/skill)** `⭐ 3` — AI Agent Skills navigation hub with 5,000+ skills across 22 functional categories. Search, filter, and discover skills for Claude Code, Codex CLI, Hermes, OpenCode, and OpenClaw. Pure static site, no backend needed.
+
+|- **[claude-northstar](https://github.com/Nisarg38/claude-northstar)** `⭐ 1` — Transforms CLI agents from task executors into autonomous project partners.
 
 - **[linear-cli](https://github.com/phnx-labs/linear-cli)** `⭐ 1` — Single-file Python CLI for Linear (the issue tracker), zero dependencies. Designed for use as a subagent tool by Claude Code, Codex, Gemini, or Cursor; ships a SKILL.md for drop-in Claude Code integration. MIT.
 


### PR DESCRIPTION
Add [Skill Hub](https://github.com/rdone4425/skill) — an AI Agent Skills navigation hub with 5,000+ skills across 22 categories. Search, filter, and discover skills for Claude Code, Codex CLI, Hermes, OpenCode, and OpenClaw.

**Features:**
- 5,073 skills indexed across 22 functional categories
- Search, filter, sort, and group view
- Multi-platform: Claude Code, Codex, Hermes, OpenCode, OpenClaw
- Pure static site (no backend), MIT licensed

https://skill.442595.xyz/