### PR TITLE
Add 5dive (self-hosted OSS coding-agent orchestration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ Multi-agent coordination, swarm patterns, and autonomous execution loops. Sorted
 
 - **[the-perfect-orchestrator](https://github.com/daman8271/the-perfect-orchestrator)** `⭐ 1` — One lead Claude Code session commands N autonomous workers in tmux panes — spawn, brief, monitor, then adversarially verify results. Pure bash + tmux, zero daemons, coordination via plain files. Also a Claude Code plugin shipping the `/orch` skill. MIT.
 
-- **[5dive](https://5dive.ai)** `[5dive]` — Hosted platform for always-on autonomous coding agents: one-command agent create, cron + heartbeat scheduling, multi-agent orchestration, Telegram control, and a babysit + needs-you triage dashboard. BYO model/account. Runs Claude Code, Codex, Grok, and more. Proprietary, hosted.
+- **[5dive](https://github.com/5dive-ai/5dive)** `⭐ 15` — Run a company of AI coding agents on a server you own: one-command spin-up of named agents (Claude Code, Codex, Grok, and more), cron + heartbeat scheduling, multi-agent orchestration, Telegram control, and a babysit + needs-you triage dashboard. Self-hosted. MIT.
 
 ### Agent infrastructure
 

--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ Multi-agent coordination, swarm patterns, and autonomous execution loops. Sorted
 
 - **[the-perfect-orchestrator](https://github.com/daman8271/the-perfect-orchestrator)** `⭐ 1` — One lead Claude Code session commands N autonomous workers in tmux panes — spawn, brief, monitor, then adversarially verify results. Pure bash + tmux, zero daemons, coordination via plain files. Also a Claude Code plugin shipping the `/orch` skill. MIT.
 
-- **[5dive](https://5dive.ai)** `[5dive]` — Hosted platform that runs coding agents (Claude Code, Codex, Grok, and more) as always-on cloud teammates: one-command create, cron + heartbeat scheduling, multi-agent orchestration, Telegram control, and a dashboard with babysit/needs-you triage. BYO model. Proprietary.
+- **[5dive](https://5dive.ai)** `[5dive]` — Hosted platform for always-on autonomous coding agents: one-command agent create, cron + heartbeat scheduling, multi-agent orchestration, Telegram control, and a babysit + needs-you triage dashboard. BYO model/account. Runs Claude Code, Codex, Grok, and more. Proprietary, hosted.
 
 ### Agent infrastructure
 

--- a/README.md
+++ b/README.md
@@ -377,6 +377,8 @@ Multi-agent coordination, swarm patterns, and autonomous execution loops. Sorted
 
 - **[the-perfect-orchestrator](https://github.com/daman8271/the-perfect-orchestrator)** `⭐ 1` — One lead Claude Code session commands N autonomous workers in tmux panes — spawn, brief, monitor, then adversarially verify results. Pure bash + tmux, zero daemons, coordination via plain files. Also a Claude Code plugin shipping the `/orch` skill. MIT.
 
+- **[5dive](https://5dive.ai)** `[5dive]` — Hosted platform that runs coding agents (Claude Code, Codex, Grok, and more) as always-on cloud teammates: one-command create, cron + heartbeat scheduling, multi-agent orchestration, Telegram control, and a dashboard with babysit/needs-you triage. BYO model. Proprietary.
+
 ### Agent infrastructure
 
 Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by GitHub stars.


### PR DESCRIPTION
Adds **5dive** under *Harnesses & orchestration → Orchestrators & autonomous loops*, alongside similar self-hosted platforms (AgentsMesh, claude-flow).

[5dive](https://github.com/5dive-ai/5dive) is an open-source (MIT) tool to run a company of AI coding agents on a server you own — spin up named agents (Claude Code, Codex, Grok, and more), put them on an org chart with a shared backlog, schedule them (cron + heartbeat), let them hand off work and multi-agent orchestrate, control from Telegram, and triage in a babysit / needs-you dashboard.

Repo: https://github.com/5dive-ai/5dive