### PR TITLE
Add UACOS to Agent infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[claude-northstar](https://github.com/Nisarg38/claude-northstar)** `⭐ 1` — Transforms CLI agents from task executors into autonomous project partners.
 
+- **[UACOS](https://github.com/caotiensinh/uacos)** `⭐ 0` — Local-first safety and context layer for AI coding agents: AST-based context compression, patch-scope safety gates with secret scanning, transaction rollback independent of git, and a built-in local MCP server. Not an agent itself — sits underneath Aider/Cline/OpenHands/Claude Code. MIT.
+
 ---
 
 ## Contributing


### PR DESCRIPTION
Adds UACOS (https://github.com/caotiensinh/uacos) to the Agent infrastructure section.

UACOS is a local-first safety and context layer for AI coding agents — not an
agent itself. It sits underneath tools like Aider, Cline, OpenHands, or
Claude Code and adds:

- AST-based context compression (Python full outline, JS/TS parser)
- A typed, queryable local memory (decisions/errors/regression rules with
  confidence + invalidation)
- A patch safety gate: file/dir scope allowlists, added-line caps, and
  secret scanning on diff-added-lines
- A transaction/checkpoint engine that can roll back file changes
  independently of git
- A release gate bundling compile + tests + self-check into one pass/fail
  check
- A built-in local-only MCP server

MIT licensed, Python 3.9+. Placed at the end of the section per current star
count (0 — freshly published).