### PR TITLE
Add schliff (deterministic AGENTS.md/SKILL.md linter) to Agent infras…

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[pi-builder](https://github.com/arosstale/pi-builder)** `⭐ 5` — TypeScript monorepo that wraps any installed CLI coding agent (Claude Code, Aider, OpenCode, Codex, Gemini CLI, Goose, Plandex, SWE-agent, Crush, gptme) behind a single interface; capability-based routing, health caching, fallback chains, SQLite persistence, and a streaming OrchestratorService. MIT.
 
+- **[schliff](https://github.com/Zandereins/schliff)** `⭐ 4` — Deterministic quality linter for agent instruction files (`AGENTS.md`, `SKILL.md`, `CLAUDE.md`, `.cursorrules`) with deterministic auto-fixes, anti-gaming detection, and a GitHub Action CI gate; no LLM in the scoring path. MIT.
+
 - **[OSOP](https://github.com/Archie0125/osop-agent-rules)** `⭐ 3` — Universal workflow logging protocol for CLI coding agents; produces `.osop` workflow definitions and `.osoplog.yaml` execution records. Supports Claude Code, Codex, Cursor, Windsurf, Aider, Cline, Roo Code, Devin, and OpenClaw. Includes a [visual editor](https://osop-editor.vercel.app) and [spec](https://github.com/Archie0125/osop-spec).
 
 - **[linear-cli](https://github.com/phnx-labs/linear-cli)** `⭐ 2` — Single-file Python CLI for Linear (the issue tracker), zero dependencies. Designed for use as a subagent tool by Claude Code, Codex, Gemini, or Cursor; ships a SKILL.md for drop-in Claude Code integration. MIT.


### PR DESCRIPTION
Adds schliff to Agent infrastructure, star-sorted (4 stars, between OSOP at 3 and zosma-qa/Praman at 9).

Per the inclusion criteria: CLI tool (`pip install schliff`), reads and writes code autonomously (~32% of its findings ship as deterministic auto-fix patches it applies itself), active project (v8.4.0 on PyPI this week, 1,347 tests). It lints/scores the instruction files the other tools on this list consume — AGENTS.md, SKILL.md, CLAUDE.md, .cursorrules — deterministically, with no LLM in the scoring path, plus a GitHub Action for CI gating.