### PR TITLE
Add m1nd to Agent infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[AgentPack](https://github.com/vishal2612200/agentpack)** `⭐ 21` — Local context engine for CLI coding agents: routes tasks to relevant files, tests, repo rules, skills, and commands, then writes compact context packs and MCP/CLI receipts for Claude Code, Codex, Cursor, Windsurf, and other agents.
 
+- **[m1nd](https://github.com/maxkle1nz/m1nd)** `⭐ 20` — Local-first MCP server that gives a CLI coding agent a neuro-symbolic code graph over the repo: `impact`/`why`/change-reasoning across a call + cross-file-imports graph (10 languages), calibrated-trust retrieval that returns `abstain`/`insufficient_evidence` instead of guessing, and persistent agent memory. A SessionStart hook pre-orients the agent before its first turn. Works with Claude Code, Codex, Cursor, and any MCP client. Rust, MIT.
+
 - **[Unship](https://github.com/mbenhard/unship)** `⭐ 14` — Local CLI and browser picker for comparing temporary UI variants created by coding agents, then keeping one and cleaning up unused code. MIT.
 
 - **[Agent Memory System](https://github.com/RavByte-AI/agent-memory-system)** `⭐ 12` — Persistent memory infrastructure for AI coding agents and multi-agent workflows. MIT.


### PR DESCRIPTION
Adds **[m1nd](https://github.com/maxkle1nz/m1nd)** to the *Agent infrastructure* subsection.

m1nd is a local-first MCP server that gives a CLI coding agent a neuro-symbolic code graph over the repo — `impact`/`why`/change-reasoning over a call + cross-file-imports graph, calibrated-trust retrieval that returns `abstain`/`insufficient_evidence` rather than guessing, and persistent agent memory. It also ships a SessionStart hook that pre-orients the agent before its first turn. Works with Claude Code, Codex, Cursor, and any MCP client. Rust, MIT.

**Inclusion requirements:**
- CLI/terminal interface: yes — it runs as an MCP server over stdio (`npx -y @maxkle1nz/m1nd`) that CLI agents attach to, plus a SessionStart hook.
- Reads/writes code or runs commands: yes — it reads the repo into a graph and exposes `apply`/`apply_batch` write tools (with an optional post-write `verify` round-trip).
- Valid, active project: yes — actively maintained, MIT-licensed.

**Placement:** sorted by stars (20) — inserted between AgentPack (⭐ 21) and Unship (⭐ 14). Sits alongside the existing MCP/context analogues in this subsection (agent-lsp, Vestige, pi-mem, AgentPack).

Thanks for maintaining this list.