### PR TITLE
Add AI Agent Safety Starter Pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 ---
 
+- **[AI Agent Safety Starter Pack](https://github.com/el-zachariah/ai-agent-safety-starter-pack)** `⭐ 0` — Local repo preflight CLI plus Claude Code `/agent-preflight` command for checking agent configs, package scripts, and Yellow/Red repo-risk signals before terminal coding agents get edit/test/shell scope. MIT.
+
 ## Contributing
 
 PRs welcome! To add an entry, please ensure it meets these criteria:


### PR DESCRIPTION
Adds the free AI Agent Safety Starter Pack repo to Agent infrastructure.

Why it fits:
- terminal/CLI-local preflight scanner plus Claude Code `/agent-preflight` command
- helps terminal coding agents check repo-risk signals before edit/test/shell scope
- links only the free GitHub repo; no paid checkout link
- duplicate search found no agent-preflight / agent-safety-preflight / ai-agent-safety-starter-pack entry in the README before submission