### PR TITLE
Add Proliferate to session managers & parallel runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,8 @@ Tools for running and managing multiple agent sessions side-by-side. Sorted by G
 
 - **[AgentBox](https://github.com/madarco/agentbox)** `⭐ 212` — Run multiple coding agents in parallel, each teleported into its own sandboxed VM (local Docker, self-hosted, or cloud: Hetzner/Daytona/Vercel/E2B); sub-second checkpoints, per-box browser/VS Code/shells, git creds kept on the host. Works with Claude Code, Codex, and OpenCode. MIT.
 
+- **[Proliferate](https://github.com/proliferate-ai/proliferate)** `⭐ 147` — Open-source local and cloud agent IDE for Claude Code, Codex, Gemini CLI, OpenCode, and similar coding agents; parallel workspaces, subagents, plugins, MCP, and review/merge flow around real CLI sessions.
+
 - **[AgentPipe](https://github.com/kevinelliott/agentpipe)** `⭐ 143` — CLI/TUI app that orchestrates multi-agent conversations by enabling different AI CLI tools (Claude Code, Gemini, Qwen, etc.) to communicate in shared rooms. MIT.
 
 - **[amux](https://github.com/andyrewlee/amux)** `⭐ 133` — Terminal UI designed for running multiple coding agents in parallel.


### PR DESCRIPTION
Adds Proliferate to the `Harnesses & orchestration -> Session managers & parallel runners` section.

Why it fits:
- open-source local and cloud agent IDE around real CLI coding-agent sessions
- supports Claude Code, Codex, Gemini CLI, OpenCode, and similar tools
- parallel workspaces, subagents, plugins, MCP, and review/merge flow

Placed by current GitHub stars (`147`) between AgentBox (`212`) and AgentPipe (`143`).

Source:
- https://github.com/proliferate-ai/proliferate
- https://proliferate.com/docs