### PR TITLE
Add iris to Session managers & parallel runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,8 @@ Tools for running and managing multiple agent sessions side-by-side. Sorted by G
 
 - **[tmuxlet](https://github.com/CodefiLabs/tmuxlet)** `⭐ 6` — Rust CLI that runs interactive coding CLIs (Claude, Codex, Gemini, opencode, pi, Cursor) inside tmux and exposes a normalized `claude -p` style blocking interface. Single binary, zero deps. Works against the regular Claude subscription bucket (not the separate Agent SDK credit) by driving interactive Claude Code from the outside.
 
+- **[iris](https://github.com/itzenata/iris-tui)** `⭐ 2` — Live TUI supervisor for every active Claude Code session: status, tokens, estimated cost, and one-pane approval of pending tool calls via a PreToolUse hook. Rust, MIT.
+
 - **[Agent CLI Menu](https://github.com/roypadina/AgentCliMenu)** `⭐ 1` — macOS TUI and menu-bar app to start or resume Claude Code and Codex sessions; frecency project launcher plus full-transcript fuzzy search across past sessions, with a working-directory confidence gate. MIT.
 
 - **[PATAPIM](https://patapim.ai)** — Terminal IDE with a 9-terminal grid for running multiple CLI coding agents simultaneously; features AI state detection, built-in Whisper voice dictation, LAN remote access, and an embedded MCP browser. Built with Electron and node-pty. Freemium.


### PR DESCRIPTION
Adds [iris](https://github.com/itzenata/iris-tui) — a live supervisor TUI for every active Claude Code session. It tails the transcripts Claude Code writes (read-only, local-only): per-session status/model/tokens/estimated cost with an aggregate counter, live activity feed, tool-usage histogram, and centralized approve/deny of pending tool calls via a PreToolUse hook with a heartbeat fallback so sessions never hang.

- Terminal interface: yes (ratatui TUI + `iris ls` one-shot mode)
- Active: v0.2.0 released today, on crates.io as `iris-tui`
- Placed by star count (⭐ 2) in Session managers & parallel runners