### PR TITLE
Add Tree Ring Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,6 +501,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[linear-cli](https://github.com/phnx-labs/linear-cli)** `⭐ 2` — Single-file Python CLI for Linear (the issue tracker), zero dependencies. Designed for use as a subagent tool by Claude Code, Codex, Gemini, or Cursor; ships a SKILL.md for drop-in Claude Code integration. MIT.
 
+- **[Tree Ring Memory](https://github.com/TerminallyLazy/Tree-Ring-Memory)** `⭐ 2` — Local-first Rust CLI/framework for coding-agent memory lifecycle: project-scoped SQLite/FTS recall, evidence-backed lessons, redaction/delete, consolidation, portable skill docs, and a Ratatui operator console. MIT.
+
 - **[claude-northstar](https://github.com/Nisarg38/claude-northstar)** `⭐ 1` — Transforms CLI agents from task executors into autonomous project partners.
 
 ---


### PR DESCRIPTION
## Summary
- add Tree Ring Memory to Agent infrastructure
- place it with the current 2-star entries to preserve section ordering

## Why it belongs
- Tree Ring Memory is a local-first Rust CLI/framework for coding-agent memory lifecycle work
- it fits alongside existing memory/context infrastructure entries such as Vestige, pi-mem, AgentPack, and Agent Memory System
- it provides SQLite/FTS recall, evidence-backed lessons, redaction/delete, consolidation, portable skill docs, and a Ratatui operator console

## Checks
- git diff --check
- verified https://github.com/TerminallyLazy/Tree-Ring-Memory returns HTTP 200
- tried `npx awesome-lint`; it fails on the repository baseline with existing format/topic/contributing errors across the README