### PR TITLE
Add Hivelore to Agent infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[claude-northstar](https://github.com/Nisarg38/claude-northstar)** `⭐ 1` — Transforms CLI agents from task executors into autonomous project partners.
 
+- **[Hivelore](https://github.com/Doucs91/hivelore)** `⭐ 1` — Deterministic policy gate for agent-written code: a lesson captured via MCP (`mem_tried`) becomes a **validated** regex/AST/test guard that Git hooks and CI use to refuse any diff reintroducing the documented mistake; briefs any agent with the team's repo-specific rules over MCP. TypeScript CLI, npm (`@hivelore/cli`). Apache-2.0.
+
 ---
 
 ## Contributing


### PR DESCRIPTION
Adds [Hivelore](https://github.com/Doucs91/hivelore) under **Harnesses & orchestration → Agent infrastructure** (placed at the bottom by star count).

**Meets the inclusion criteria:** it has a terminal/CLI interface (`hivelore init`, `enforce`, `sensors`, `run -- <agent>`) and runs commands autonomously (git-hook + CI gate, MCP server).

Hivelore is a deterministic policy gate for agent-written code: a lesson captured via MCP (`mem_tried`) becomes a **validated** guard — regex, ast-grep structural pattern, or a command/test oracle — that Git hooks and CI use to refuse any diff reintroducing the documented mistake. Same diff, same verdict on every machine. TypeScript, npm (`@hivelore/cli`), Apache-2.0.