### PR TITLE
Add Waveloom

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ Forkable, extensible, and community-driven. Sorted by GitHub stars. Provider tag
 
 - **[Keen Code](https://github.com/mochow13/keen-code)** `⭐ 44` — Go-based CLI coding agent focused on efficient context management — uses lean TurnMemory summaries instead of raw tool traces to maximize context efficiency. 9+ providers, skill-driven MCP servers, and full transparency with every prompt, design doc, and implementation plan saved as markdown. MIT.
 
+- **[Waveloom](https://github.com/Menfre01/waveloom)** `⭐ 35` — Go terminal-native coding agent with Bubble Tea TUI; DeepSeek V4 prompt caching for long-context efficiency; Claude Code-compatible UX with skill/MCP auto-discovery; four-tier context compaction, three subagent modes (Fork/Cold/Explore), permission engine, and plan mode. Single binary, zero runtime deps. Apache-2.0.
+
 - **[Smelt](https://github.com/leonardcser/smelt)** `⭐ 29` — Rust TUI coding agent; multi-provider (Anthropic, OpenAI, Ollama, GitHub Copilot, any OpenAI-compatible endpoint), four modes (Normal/Plan/Apply/Yolo), granular permission system, parallel subagents, vim keybindings, and headless scriptable mode. MIT.
 
 - **[Zap](https://github.com/zap-coding-agent/zap-coding-agent)** `⭐ 23` — Skill-first Rust TUI coding agent that injects only the context your task needs — no system prompt bloat. Single binary, no runtime. Supports Claude, Gemini, OpenAI, and local models via LM Studio; code-indexed via SQLite for fast symbol lookup; MCP support. MIT.

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Forkable, extensible, and community-driven. Sorted by GitHub stars. Provider tag
 
 - **[Keen Code](https://github.com/mochow13/keen-code)** `⭐ 44` — Go-based CLI coding agent focused on efficient context management — uses lean TurnMemory summaries instead of raw tool traces to maximize context efficiency. 9+ providers, skill-driven MCP servers, and full transparency with every prompt, design doc, and implementation plan saved as markdown. MIT.
 
-- **[Waveloom](https://github.com/Menfre01/waveloom)** `⭐ 35` — Go terminal-native coding agent with Bubble Tea TUI; DeepSeek V4 prompt caching for long-context efficiency; Claude Code-compatible UX with skill/MCP auto-discovery; four-tier context compaction, three subagent modes (Fork/Cold/Explore), permission engine, and plan mode. Single binary, zero runtime deps. Apache-2.0.
+- **[Waveloom](https://github.com/Menfre01/waveloom)** `⭐ 35` — Go terminal-native coding agent with Bubble Tea TUI; DeepSeek V4 prompt caching for long-context efficiency; Claude Code-compatible UX with skill/MCP auto-discovery; four-tier context compaction, three subagent modes (Fork/Cold/Explore), permission engine, and plan mode. Single ~19 MB binary, zero runtime deps. Apache-2.0.
 
 - **[Smelt](https://github.com/leonardcser/smelt)** `⭐ 29` — Rust TUI coding agent; multi-provider (Anthropic, OpenAI, Ollama, GitHub Copilot, any OpenAI-compatible endpoint), four modes (Normal/Plan/Apply/Yolo), granular permission system, parallel subagents, vim keybindings, and headless scriptable mode. MIT.
 


### PR DESCRIPTION
**Waveloom** — A Go terminal-native coding agent with Bubble Tea TUI.

## Why it belongs here

- **Terminal-native**: reads/writes files, runs shell commands, invokes build tools directly
- **DeepSeek V4 optimized**: prompt caching integration for cost-efficient long-context sessions
- **Claude Code-compatible UX**: slash commands, plan mode, skill/MCP auto-discovery — zero friction for Claude Code users
- **Engineering depth**: four-tier context compaction (Snip/Prune/Summarize), three subagent modes with parallel scheduling (Fork/Cold/Explore), permission gatekeeper rule engine
- **Go single binary**: cross-platform (Windows/Linux/macOS), zero runtime dependencies, ~19 MB

## Checklist

- [x] Has a CLI/terminal interface
- [x] Can read/write code and run commands autonomously
- [x] Active project with recent updates
- [x] Entry sorted by star count (`⭐ 35`)
- [x] Format matches existing entries