### PR TITLE
Add construct to Harnesses & orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ Tools for running and managing multiple agent sessions side-by-side. Sorted by G
 
 - **[tmuxlet](https://github.com/CodefiLabs/tmuxlet)** `⭐ 6` — Rust CLI that runs interactive coding CLIs (Claude, Codex, Gemini, opencode, pi, Cursor) inside tmux and exposes a normalized `claude -p` style blocking interface. Single binary, zero deps. Works against the regular Claude subscription bucket (not the separate Agent SDK credit) by driving interactive Claude Code from the outside.
 
-- **[construct](https://github.com/construct-worlds/construct)** `⭐ 3` — Terminal-native agentic development environment: fleet TUI for Codex, Claude Code, Antigravity, Grok, and smith with fork/merge, collaborative Program Markdown orchestration, generative widgets, MCP agent coordination, and browser remote control. Rust, MIT.
+- **[construct](https://github.com/construct-worlds/construct)** `⭐ 3` — Terminal-native agentic development environment: fleet TUI for coding agent CLIs (Codex, Claude Code, Antigravity, Grok) with fork/merge, collaborative Program Markdown orchestration, generative widgets, agent-to-agent orchestration. Single Rust binary.
 
 - **[Agent CLI Menu](https://github.com/roypadina/AgentCliMenu)** `⭐ 1` — macOS TUI and menu-bar app to start or resume Claude Code and Codex sessions; frecency project launcher plus full-transcript fuzzy search across past sessions, with a working-directory confidence gate. MIT.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 A curated list of **90+ CLI coding agents** — AI-powered tools that live in your terminal, read/edit repos, and run commands — plus the **harnesses** that orchestrate, sandbox, or extend them.
 
-> **Last updated:** 2026-07-06
+> **Last updated:** 2026-07-11
 
 ### What is a CLI coding agent?
 
@@ -312,6 +312,8 @@ Tools for running and managing multiple agent sessions side-by-side. Sorted by G
 - **[pi-boss](https://github.com/skyfallsin/pi-boss)** `⭐ 7` — Multi-agent orchestration for the Pi coding agent; spawns sub-agents in visible tmux panes with task delegation, monitoring, and coordination. MIT.
 
 - **[tmuxlet](https://github.com/CodefiLabs/tmuxlet)** `⭐ 6` — Rust CLI that runs interactive coding CLIs (Claude, Codex, Gemini, opencode, pi, Cursor) inside tmux and exposes a normalized `claude -p` style blocking interface. Single binary, zero deps. Works against the regular Claude subscription bucket (not the separate Agent SDK credit) by driving interactive Claude Code from the outside.
+
+- **[construct](https://github.com/construct-worlds/construct)** `⭐ 3` — Terminal-native agentic development environment: fleet TUI for Codex, Claude Code, Antigravity, Grok, and smith with fork/merge, collaborative Program Markdown orchestration, generative widgets, MCP agent coordination, and browser remote control. Rust, MIT.
 
 - **[Agent CLI Menu](https://github.com/roypadina/AgentCliMenu)** `⭐ 1` — macOS TUI and menu-bar app to start or resume Claude Code and Codex sessions; frecency project launcher plus full-transcript fuzzy search across past sessions, with a working-directory confidence gate. MIT.
 


### PR DESCRIPTION
Adds [construct](https://github.com/construct-worlds/construct) to **Session managers & parallel runners** (star-sorted position between tmuxlet and Agent CLI Menu).

construct is a terminal-native agentic development environment: a fleet TUI that wraps Codex, Claude Code, Antigravity, Grok, and smith; fork/merge across harnesses; collaborative Program Markdown orchestration; MCP tools for agent-to-agent coordination; generative widgets; and a browser remote-control web client.