### PR TITLE
Add GoodMemory to agent infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,6 +533,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[schliff](https://github.com/Zandereins/schliff)** `⭐ 8` — Deterministic quality linter for agent instruction files (`AGENTS.md`, `SKILL.md`, `CLAUDE.md`, `.cursorrules`) with deterministic auto-fixes, anti-gaming detection, and a GitHub Action CI gate; no LLM in the scoring path. MIT.
 
+- **[GoodMemory](https://github.com/hjqcan/GoodMemory)** `⭐ 8` — Local-first, auditable memory layer for Codex and Claude Code; its CLI installs scoped recall hooks and read-only MCP, with SQLite persistence by default plus opt-in governed writeback that can be inspected and reversed. MIT.
+
 - **[clu](https://github.com/arjia-labs/clu)** `⭐ 7` — Codified Likeness Utility: a SQLite-backed issue tracker for coordinating fleets of AI coding agents. Atomic task claim, dependency graphs, workflows & checkpoints, and an audit log. CLI-native with clean `--json` output, built to be driven by agents. Go.
 
 - **[Terminai](https://github.com/emosenkis/terminai)** `⭐ 6` — Makes your terminal of choice AI-enabled using your favorite CLI coding agent. Completely transparent until you activate the AI with Ctrl-Space, then runs your agent in an overlay with access to your terminal.


### PR DESCRIPTION
## Summary

- add GoodMemory to Agent infrastructure at its current 8-star position
- describe its coding-agent CLI path: scoped recall hooks, read-only MCP, local SQLite, and opt-in governed writeback

## Why it belongs

GoodMemory is a local-first, MIT-licensed memory layer with a CLI specifically supporting Codex and Claude Code. It fits beside existing memory/context infrastructure such as Vestige, pi-mem, AgentPack, Data Olympus, and Agent Memory System.

## Checks

- rebased on the current upstream `main`
- `git diff --check`
- verified the project URL returns HTTP 200
- verified 8 stars, MIT license, and active repository status through the GitHub API
- `npx awesome-lint` was also run on the original submission; it reports the repository existing baseline format/topic/contributing errors across the README, including all current entry lines, rather than a GoodMemory-specific regression