### PR TITLE
Add Agent Teams AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,8 @@ Tools for running and managing multiple agent sessions side-by-side. Sorted by G
 
 - **[Cate](https://github.com/0-AI-UG/cate)** `⭐ 1.8k` — Desktop app that runs terminals, Claude Code agent panels, editors, and browsers on an infinite zoomable canvas; multiple agent sessions sit side by side and panels can dock into tabs or detach into separate windows. Built with Electron and node-pty. MIT.
 
+- **[Agent Teams AI](https://github.com/777genius/agent-teams-ai)** `⭐ 1.6k` - Cross-platform desktop control plane with integrated terminals and a Kanban board for autonomous coding-agent teams; agents coordinate, message each other, and review work across Codex, Claude Code, OpenCode, Cursor, Grok, GitHub Copilot, Kiro, Z.AI, MiniMax, Kimi, and 75+ model providers. AGPL-3.0.
+
 - **[Nimbalyst](https://github.com/nimbalyst/nimbalyst)** `⭐ 1.2k` — Open-source visual workspace for building with Codex, Claude Code, and more; manage your agents, edit the work visually, and track tasks. MIT.
 
 - **[jean](https://github.com/coollabsio/jean)** `⭐ 1.1k` — Administer multiple projects, worktrees, and sessions with Claude CLI.


### PR DESCRIPTION
## Summary

- Add Agent Teams AI to Session managers and parallel runners
- Place it by current GitHub star count
- Describe its integrated terminals, Kanban workflow, agent coordination, messaging, and peer review

The project provides terminal access and autonomous code execution through supported coding-agent runtimes, including Codex, Claude Code, and OpenCode. It is active, cross-platform, and open source under AGPL-3.0.

Disclosure: I am affiliated with Agent Teams AI.

## Checks

- Confirmed there is no existing Agent Teams AI entry or submission
- `git diff --check`

Disclosure: I maintain Agent Teams AI.