### PR TITLE
Add Tura to open-source CLI coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Forkable, extensible, and community-driven. Sorted by GitHub stars. Provider tag
 - **[Grinta](https://github.com/josephsenior/Grinta-Coding-Agent)** `⭐ 20` — Local-first, provider-agnostic terminal coding agent built for long-horizon autonomous execution; durable state and recovery, context management, structured tool orchestration, LSP/DAP integration, and validation-gated completion. Python, MIT.
 
 - **[Binharic](https://github.com/CogitatorTech/binharic-cli)** `⭐ 17` — A multi-provider "tech-priest persona" coding agent CLI (stylized, tool-using).
-- **[Tura](https://github.com/Tura-AI/tura)** `⭐ 8` — Local AGPL-3.0 coding agent with CLI/TUI/GUI, task-scoped context, macro `command_run` execution, verification, and published long-horizon benchmark results.
+- **[Tura](https://github.com/Tura-AI/tura)** `⭐ 8` — Tura is a local, open-source coding agent for developers who are tired of vague skill claims, token-saving extensions with no evidence, and agents that change a repository before understanding it. AGPL-3.0.
 
 - **[Darce](https://github.com/AmerSarhan/darce-cli)** `⭐ 5` — Ultralight (14 kB) multi-model CLI agent built with Ink; 7 tools, smart model routing across providers, streaming, session resume, and slash commands. MIT.
 

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Forkable, extensible, and community-driven. Sorted by GitHub stars. Provider tag
 - **[Grinta](https://github.com/josephsenior/Grinta-Coding-Agent)** `⭐ 20` — Local-first, provider-agnostic terminal coding agent built for long-horizon autonomous execution; durable state and recovery, context management, structured tool orchestration, LSP/DAP integration, and validation-gated completion. Python, MIT.
 
 - **[Binharic](https://github.com/CogitatorTech/binharic-cli)** `⭐ 17` — A multi-provider "tech-priest persona" coding agent CLI (stylized, tool-using).
+- **[Tura](https://github.com/Tura-AI/tura)** `⭐ 8` — Local AGPL-3.0 coding agent with CLI/TUI/GUI, task-scoped context, macro `command_run` execution, verification, and published long-horizon benchmark results.
 
 - **[Darce](https://github.com/AmerSarhan/darce-cli)** `⭐ 5` — Ultralight (14 kB) multi-model CLI agent built with Ink; 7 tools, smart model routing across providers, streaming, session resume, and slash commands. MIT.
 


### PR DESCRIPTION
Hi! I maintain Tura. It meets the list's inclusion requirements: it has a terminal interface, can read and write repositories, and can run commands autonomously. Tura is AGPL-3.0 and currently has 8 GitHub stars.

I placed the entry in the Open Source section between the 17-star and 5-star projects, preserving the required descending star order and entry format.

Repository: https://github.com/Tura-AI/tura
Benchmark: https://turaai.net/benchmark

Thanks for considering it.