### PR TITLE
Add Agon to Orchestrators & autonomous loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,8 @@ Multi-agent coordination, swarm patterns, and autonomous execution loops. Sorted
 
 - **[agx](https://github.com/ramarlina/agx)** `⭐ 26` — Checkpoint-based execution engine for AI coding agents; durable Wake→Work→Sleep loops that resume instantly across sessions. Supports Claude Code, Codex CLI, Gemini CLI, and Ollama. CLI + web dashboard + macOS app.
 
+- **[Agon](https://github.com/AutoResearch-Factory/Agon)** `⭐ 26` — Claude Code plugin for autonomous research: runs a topic→idea→proposal→experiment loop with separate scientist, coder, and auditor roles.
+
 - **[5dive](https://github.com/5dive-ai/5dive)** `⭐ 21` — Run a company of AI coding agents on a server you own: one-command spin-up of named agents (Claude Code, Codex, Grok, and more), cron + heartbeat scheduling, multi-agent orchestration, Telegram control, and a babysit + needs-you triage dashboard. Self-hosted. MIT.
 
 - **[Galley](https://github.com/shinpr/galley)** `⭐ 14` — Local-first runtime for supervised AI coding tasks: isolated git worktrees, supervisor review against acceptance criteria, retry/escalate loops, on-disk run evidence, and PR handoff. Supports Codex CLI and Claude Code. Go, MIT.


### PR DESCRIPTION
Agon (arXiv:2606.24177) is a Claude Code plugin that runs autonomous research through a topic→idea→proposal→experiment loop, with separate scientist, coder, and auditor roles per run. Same category as The Factory and agx already in this section — a harness driving Claude Code through a structured loop, just for research instead of general SDLC work. ~26 stars, pushed today.