### PR TITLE
Add agentty (native C++26 terminal coding agent)

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ Forkable, extensible, and community-driven. Sorted by GitHub stars. Provider tag
 
 - **[Octomind](https://github.com/Muvon/octomind)** `⭐ 83` — Open-source, model-agnostic AI agent runtime with community tap registry (`developer:rust`, `doctor:blood`, `legal:contracts`), MCP support with runtime self-extension, 13+ providers, and adaptive compression. Written in Rust. Apache-2.0.
 
+- **[agentty](https://github.com/1ay1/agentty)** `⭐ 82` — Native C++26 terminal coding agent and drop-in claude-code alternative; single ~13.6 MB static binary with sub-millisecond cold start and zero runtime deps (no Node/Python/Electron). Sandboxed by default (Bubblewrap/`sandbox-exec`), model-agnostic (Claude, OpenAI, Groq, OpenRouter, Together, Cerebras, local Ollama), runs inside Zed over ACP, and drives air-gapped hosts over SSH. Linux/macOS/Windows/Termux. MIT.
+
 - **[Crab Code](https://github.com/lingcoder/crab-code)** `⭐ 74` — Rust-native agentic coding CLI aligned with Claude Code's toolset and permission model; works with any LLM provider (Anthropic/OpenAI/DeepSeek/Bedrock/Vertex). 27 crates, 4,700+ tests, layered config system. Apache-2.0.
 
 - **[San](https://github.com/genai-io/san)** `⭐ 68` — Go terminal-native runtime for specialized AI agents; provider-agnostic (Anthropic, OpenAI, Google, DeepSeek, Moonshot, Qwen, MiniMax, GLM), runs Claude Code skills/plugins/MCP unmodified, swappable search backends, custom personas, sandboxed subagents, lifecycle hooks, and a self-evolving memory loop. Single ~12 MB binary, zero runtime deps. Apache-2.0.


### PR DESCRIPTION
Adds **agentty** to *Terminal-native coding agents → Open Source*, placed by star count (between Octomind ⭐83 and Crab Code ⭐74).

[agentty](https://github.com/1ay1/agentty) is a native **C++26** terminal coding agent — a drop-in claude-code alternative that ships as a single ~13.6 MB static binary (no Node/Python/Electron), cold-starts in under a millisecond, and sandboxes every shell call by default (Bubblewrap / `sandbox-exec`). It's model-agnostic (Claude, OpenAI, Groq, OpenRouter, Together, Cerebras, or a local Ollama model), runs inside Zed over ACP, and can drive an agent on an air-gapped host with a single SSH command. Linux/macOS/Windows/Termux. MIT.

**Meets the inclusion requirements:**
- CLI/terminal interface ✅ (native TUI, not IDE-only)
- Reads/writes code and runs commands autonomously ✅
- Valid, active project ✅ (actively developed, MIT, ~82★)

Entry placed in correct star-sorted position and formatted per the Contributing guide (name+link, star badge, 1–2 line description).

Repo: https://github.com/1ay1/agentty · Site: https://agentty.org