### PR TITLE
Add Even (agent-native desktop workspace) to Session managers & parallel runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,8 @@ Tools for running and managing multiple agent sessions side-by-side. Sorted by G
 
 - **[Bwee](https://bwee.app)** — Desktop app for CLI coding agents where users build their own views (BYOUI) — custom tools and dashboards that live alongside the terminal. Persistent sessions and task management. macOS.
 
+- **[Even](https://even.dev)** — Agent-native desktop workspace: a native terminal (real shell per pane), a real in-app browser, one-click self-hosted services, and local models in one window. Runs multiple coding-agent CLIs (Claude Code, Codex, and others) side by side in the same panes you work in, each under a deny-by-default policy with a tamper-evident audit trail.
+
 ### Orchestrators & autonomous loops
 
 Multi-agent coordination, swarm patterns, and autonomous execution loops. Sorted by GitHub stars.


### PR DESCRIPTION
Adds **Even** to *Harnesses & orchestration → Session managers & parallel runners*.

Even ([even.dev](https://even.dev)) is an agent-native desktop workspace: a native terminal (real shell per pane), a real in-app browser, one-click self-hosted services, and local models in one window. You run multiple coding-agent CLIs (Claude Code, Codex, and others) side by side in the same panes you work in, each under a deny-by-default policy with a tamper-evident audit trail.

Meets the inclusion criteria:
- **Terminal interface** — a native terminal is the core surface; agents run commands in the same panes you do.
- **Runs commands autonomously** — hosted agents read/write code and execute shell commands under policy.
- **Valid, active project** — even.dev.

Placed with the other site-linked, no-GitHub-stars entries at the end of the section (after Bwee).

🤖 Generated with [Claude Code](https://claude.com/claude-code)