### PR TITLE
Add Orca (DeepSeek-native terminal coding agent)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ Forkable, extensible, and community-driven. Sorted by GitHub stars. Provider tag
 
 - **[LettaBot](https://github.com/letta-ai/lettabot)** `⭐ 327` — Personal AI assistant with persistent unified memory across Telegram, Slack, Discord, WhatsApp, and Signal; built on the Letta platform.
 
+- **[Orca](https://github.com/echoVic/blade-deepseek)** `⭐ 310` — DeepSeek-native terminal coding agent in Rust; OS-level sandboxing (Seatbelt / bwrap / Landlock+seccomp, fail-closed), persistent goal mode with stall detection, background tasks, JS workflows, folder trust, and 1M-context auto-compaction. Single binary. MIT.
+
 - **[Mini-Kode](https://github.com/minmaxflow/mini-kode)** `⭐ 304` — An educational AI coding agent CLI, intended as a readable reference implementation.
 
 - **[zot](https://github.com/patriceckhart/zot)** `⭐ 295` — Zero-overhead and lightweight coding agent harness with TUI/JSON/RPC modes, structured tools, reviewable file diffs, skills, extensions, and optional guardrails.


### PR DESCRIPTION
Adds **[Orca](https://github.com/echoVic/blade-deepseek)** to *Terminal-native coding agents → Open Source*.

**Inclusion criteria:**
- CLI/terminal interface: interactive TUI plus headless `orca exec` for scripts/CI
- Autonomous read/write/execute: full agent loop with file edits, shell, verification gates
- Active project: ~200 releases since June 2026, latest v0.2.33 (July 2026)

**Entry format:** name + GitHub link, current star count (310), 1–2 line description with the differentiators (OS sandboxing, goal mode, folder trust), license. Placed by star count between LettaBot (327) and Mini-Kode (304).