### PR TITLE
Update Hephaestus entry to Agentlas OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ Multi-agent coordination, swarm patterns, and autonomous execution loops. Sorted
 
 - **[loom](https://github.com/ghuntley/loom)** `⭐ 1.4k` — Infrastructure enabling autonomous loops to evolve products via multi-agent coordination.
 
-- **[Hephaestus](https://github.com/agentlas-ai/Hephaestus)** `⭐ 1.1k` — Open Agent OS for Claude Code, Codex, and Cursor with a meta-agent builder, A2A Hub routing, local ontology, and memory/security gates. Apache-2.0.
+- **[Agentlas OS](https://github.com/agentlas-ai/Agentlas-OS)** `⭐ 1.1k` — Local-first Agent Operation Environment (AOE) for building or borrowing specialist agents, composing teams, and running them across Claude Code, Codex, Gemini CLI, Cursor, and local models with permission and verification gates. Apache-2.0.
 
 - **[Loki Mode](https://github.com/asklokesh/loki-mode)** `⭐ 1k` — Spec-to-product autonomous loop with a built-in verification gate: a reason/act/reflect/verify closure plus a blind-review completion council that can veto "done", so it will not mark work complete until the evidence passes. Brownfield healing (`loki heal`), local-first BYO-keys, 26-tool MCP server, reads AGENTS.md. Source-available (BUSL-1.1).
 


### PR DESCRIPTION
## Summary

- Replace the retired Hephaestus repository entry with Agentlas OS.
- Update the link, current star count, supported hosts, and product description.
- Use the current public positioning: Agent Operation Environment (AOE).

## Verification

- The replacement repository is public, active, and Apache-2.0 licensed.
- The entry remains correctly sorted between the 1k and 707-star projects.
- `git diff --check` passes.

Disclosure: I am submitting this on behalf of Agentlas.
