### PR TITLE
Add Garcon to Session managers & parallel runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,8 @@ Tools for running and managing multiple agent sessions side-by-side. Sorted by G
 
 - **[Clave](https://github.com/codika-io/clave)** `⭐ 41` — Native macOS app for running multiple AI coding-agent CLIs (Claude Code, Gemini CLI, Codex) in parallel — split/grid terminal layouts, per-project session groups, a built-in git panel, and remote sessions over SSH. Fully local, no account. Electron. MIT.
 
+- **[Garcon](https://github.com/cfal/garcon)** `⭐ 40` — Self-hosted browser and mobile workspace for running and steering parallel Claude Code, Codex, Cursor Agent, OpenCode, Amp, Droid, and Pi sessions, with integrated terminal, files, diff review, Git/PR workflows, mobile approvals, scheduling, and cross-agent transfers. GPL-3.0.
+
 - **[showagent](https://github.com/aytzey/showagent)** `⭐ 35` — Bubble Tea TUI that unifies the local session stores of Claude Code, Codex, Gemini CLI, and OpenCode: fuzzy search grouped by workspace, resume via each agent's own CLI, branch local copies, and cross-agent transcript conversion into the target's native format. Scriptable (`list --json`), fully local, single Go binary. MIT.
 
 - **[Claudescope](https://github.com/vladar107/claudescope)** `⭐ 13` — Local, read-only CLI that serves a web UI to browse, search, and analyze AI coding-agent transcripts across Claude Code, Codex, Junie, pi, opencode, and Copilot CLI — sessions merged by working directory, with full-text search and token-cost analytics. npm, cross-platform. MIT.


### PR DESCRIPTION
## What

Adds [Garcon](https://github.com/cfal/garcon) to **Harnesses & orchestration > Session managers & parallel runners**, placed by its current star count.

## Why it fits

Garcon runs native Claude Code, Codex, Cursor Agent, OpenCode, Amp, Droid, and Pi sessions through a self-hosted browser and mobile workspace. It exposes real terminal sessions, live steering and approvals, integrated files and diff review, Git and pull-request workflows, scheduling, and cross-agent transfers.

- Actively maintained with tagged releases
- GPL-3.0
- Runs locally against native coding-agent CLIs and custom model endpoints

Disclosure: I maintain Garcon.
