### PR TITLE
Add TierDecay to Harnesses & orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,8 @@ Multi-agent coordination, swarm patterns, and autonomous execution loops. Sorted
 
 - **[the-perfect-orchestrator](https://github.com/daman8271/the-perfect-orchestrator)** `⭐ 1` — One lead Claude Code session commands N autonomous workers in tmux panes — spawn, brief, monitor, then adversarially verify results. Pure bash + tmux, zero daemons, coordination via plain files. Also a Claude Code plugin shipping the `/orch` skill. MIT.
 
+- **[TierDecay](https://github.com/alebgl77/tierdecay)** `⭐ 1` — Self-distilling model router: solves each task class once at an expensive model tier, distills the decision into a ≤15-line playbook entry, then probes and decays the class's default tier down (T3→T2→T1) using a ledger of predicted-vs-executed tiers. Ships adapters for Claude Code (native scout/executor/heavy-executor/oracle pipeline), Codex/AGENTS.md, Cursor, Gemini CLI, Aider, Cline, Goose, and Windsurf; a PreToolUse hook enforces state integrity. Just markdown + a shell installer, no daemon. MIT.
+
 ### Agent infrastructure
 
 Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by GitHub stars.


### PR DESCRIPTION
Adds **TierDecay** to `Harnesses & orchestration → Orchestrators & autonomous loops`, placed at the bottom by star count (⭐ 1).

**Repo:** https://github.com/alebgl77/tierdecay

**What it is:** a self-distilling model router for CLI coding agents. It solves each recurring task class once at an expensive model tier, distills the decision into a ≤15-line playbook entry, then probes and decays that class's default tier down (T3→T2→T1), using a ledger of predicted-vs-executed tiers as an empirical posterior over a cold-start routing rubric. Ships adapters for Claude Code (a native scout/executor/heavy-executor/oracle subagent pipeline), Codex/AGENTS.md, Cursor, Gemini CLI, Aider, Cline, Goose, and Windsurf. A `PreToolUse` hook enforces the state-write integrity invariant at the tool layer.

**Against the inclusion criteria:**
- *CLI / terminal interface* — yes: a `bash install.sh` equips a repo, and it drives terminal agents; not an IDE-only tool.
- *Reads/writes code or runs commands autonomously* — yes, the same way the other orchestration-layer entries here do (e.g. `great_cto`, which runs across CLIs via AGENTS.md, or `the-perfect-orchestrator`, pure bash + tmux): the harness directs the CLI agents that edit files and run commands, gated by acceptance criteria and a T3 review.
- *Valid, active project* — yes: MIT, CI green, v0.1.0 tagged.

Single entry, correct format (`⭐` badge, em-dash, license), alphabetical/star position preserved, no emoji in the description.