### PR TITLE
Add Unpeel

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ Tools for running and managing multiple agent sessions side-by-side. Sorted by G
 
 - **[Bwee](https://bwee.app)** — Desktop app for CLI coding agents where users build their own views (BYOUI) — custom tools and dashboards that live alongside the terminal. Persistent sessions and task management. macOS.
 
-- **[Unpeel](https://unpeel.com)** — Native macOS app for running and supervising multiple CLI agent sessions (Claude Code, Codex, Gemini CLI, Amp, OpenCode, Cline, and more): persistent terminals that survive app restarts, git worktree isolation for parallel agents, busy/attention notifications, and iPhone remote control via a self-hosted E2E-encrypted relay. Closed-source; free with paid remote access.
+- **[Unpeel](https://unpeel.com)** — Native macOS app built on the Ghostty terminal engine for running and remote-controlling multiple CLI agent sessions (Claude Code, Codex, Gemini CLI, Amp, OpenCode, Cline, and more): persistent terminals that survive app restarts, git worktree isolation for parallel agents, busy/attention notifications, and iPhone remote control via a self-hosted E2E-encrypted relay. Closed-source; free with paid remote access.
 
 ### Orchestrators & autonomous loops
 

--- a/README.md
+++ b/README.md
@@ -347,6 +347,8 @@ Tools for running and managing multiple agent sessions side-by-side. Sorted by G
 
 - **[Bwee](https://bwee.app)** — Desktop app for CLI coding agents where users build their own views (BYOUI) — custom tools and dashboards that live alongside the terminal. Persistent sessions and task management. macOS.
 
+- **[Unpeel](https://unpeel.com)** — Native macOS app for running and supervising multiple CLI agent sessions (Claude Code, Codex, Gemini CLI, Amp, OpenCode, Cline, and more): persistent terminals that survive app restarts, git worktree isolation for parallel agents, busy/attention notifications, and iPhone remote control via a self-hosted E2E-encrypted relay. Closed-source; free with paid remote access.
+
 ### Orchestrators & autonomous loops
 
 Multi-agent coordination, swarm patterns, and autonomous execution loops. Sorted by GitHub stars.


### PR DESCRIPTION
Adds [Unpeel](https://unpeel.com) to **Harnesses & orchestration ▸ Session managers & parallel runners**, placed with the other non-GitHub entries at the bottom of the section (after Bwee), no star badge since it's closed-source with no public repo.

Unpeel is a native macOS app for running and supervising multiple CLI agent sessions (Claude Code, Codex, Gemini CLI, Amp, OpenCode, Cline, Grok, Kimi, and more): hosted PTY sessions that persist across app restarts, git worktree isolation for parallel agents, busy/attention notifications, and remote control from an iPhone via a self-hosted end-to-end-encrypted relay. Closed-source; free download, paid tier for remote access — tagged as such in the entry.

Meets the inclusion criteria: it hosts and drives real terminal CLI agents (not IDE-only), and the link is the active product site (macOS beta available for download).