### PR TITLE
Add autoqq to Agent infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[linear-cli](https://github.com/phnx-labs/linear-cli)** `⭐ 2` — Single-file Python CLI for Linear (the issue tracker), zero dependencies. Designed for use as a subagent tool by Claude Code, Codex, Gemini, or Cursor; ships a SKILL.md for drop-in Claude Code integration. MIT.
 
+- **[autoqq](https://github.com/Migiht/autoqq)** `⭐ 2` — Linux CLI that schedules a `systemd` user timer to ping Claude Code, Codex CLI, or opencode before you sit down, so the 5h rate-limit window is already fresh instead of starting when you open your laptop. MIT.
+
 - **[claude-northstar](https://github.com/Nisarg38/claude-northstar)** `⭐ 1` — Transforms CLI agents from task executors into autonomous project partners.
 
 - **[Hivelore](https://github.com/Doucs91/hivelore)** `⭐ 1` — Deterministic policy gate for agent-written code: a lesson captured via MCP (`mem_tried`) becomes a validated regex/AST/test guard that Git hooks and CI use to refuse any diff reintroducing the documented mistake; briefs any agent with the team's repo-specific rules over MCP. TypeScript CLI, npm (`@hivelore/cli`). Apache-2.0.


### PR DESCRIPTION
Adds [autoqq](https://github.com/Migiht/autoqq) — a small Linux CLI that schedules a `systemd` user timer to send a keep-alive ping to Claude Code, Codex CLI, or opencode before the workday starts, so the 5h rate-limit window is already fresh instead of only starting when the user opens their laptop.