### PR TITLE
Add cliclaw (Telegram-driven multi-agent session manager)

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,8 @@ Tools for running and managing multiple agent sessions side-by-side. Sorted by G
 
 - **[postmortemthis](https://github.com/Softeria/postmortemthis)** `⭐ 1` — Runs every coding-agent CLI you have (Claude Code, Codex, Gemini, Qwen, Vibe) in parallel and read-only over your diff, then synthesizes their reviews into one ship / no-ship verdict. A cross-model second opinion before you ship. MIT.
 
+- **[cliclaw](https://github.com/choiyounggi/cliclaw)** `⭐ 0` — macOS daemon to drive Claude Code, Codex, Gemini, and Pi from Telegram — an independent session per chat, a confirm gate for dangerous commands (bash/git/cloud deletes), and secret auto-masking. npm `@younggichoi/cliclaw`, TypeScript/Bun. MIT.
+
 - **[PATAPIM](https://patapim.ai)** — Terminal IDE with a 9-terminal grid for running multiple CLI coding agents simultaneously; features AI state detection, built-in Whisper voice dictation, LAN remote access, and an embedded MCP browser. Built with Electron and node-pty. Freemium.
 
 - **[Bwee](https://bwee.app)** — Desktop app for CLI coding agents where users build their own views (BYOUI) — custom tools and dashboards that live alongside the terminal. Persistent sessions and task management. macOS.


### PR DESCRIPTION
Adds **cliclaw** to *Session managers & parallel runners*.

- A macOS daemon that drives Claude Code, Codex, Gemini, and Pi from **Telegram** — one independent session per chat, with a confirm gate for dangerous commands (bash/git/cloud deletes) and secret auto-masking in logs.
- CLI/daemon, active GitHub project, published on npm (`@younggichoi/cliclaw`), MIT.
- Placed at the end of the section (⭐0) per the star-sorted order.

Fits the section's "running and managing multiple agent sessions side-by-side" scope; the Telegram-first remote interface is the differentiator.