### PR TITLE
Add Nilux AI to Closed Source

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,8 @@ Proprietary agents — usable but not forkable or extensible at the source level
 
 - **[Mentat CLI](https://mentat.ai/docs/cli)** `[Mentat]` — Cloud-native coding agent CLI for managing remote Mentat agents from your terminal; auto-detects repo/branch context.
 
+- **[Nilux AI](https://github.com/nilux-dev/nilux)** `[Nilux]` — Terminal agent that reads, edits and runs code across a project and keeps its context between sessions; four approval modes, MCP servers, subagents. Pay-per-token, no subscription. `npm install -g @nilux-ai/code`
+
 ---
 
 ## Harnesses & orchestration


### PR DESCRIPTION
Adds Nilux AI to Closed Source. I'm the author.

Against the inclusion criteria:
- CLI/terminal interface — installs as `npm install -g @nilux-ai/code`, runs as `nilux` in a project directory. No IDE.
- - Reads/writes code and runs commands autonomously — searches and reads files before editing, applies diffs, executes shell commands under one of four approval modes.
- - Valid, active project — published on npm (1.0.10, this week), docs and changelog at https://nilux.dev.
Placed at the end of the section: the repository is a public tracker rather than source, so there is no star count to sort by. Happy to reword or move it if you'd rather it sat elsewhere.