### PR TITLE
Add Engine to Agent infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,6 +551,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[agent-trace](https://github.com/ertygiq/agent-trace)** `⭐ 1` — Text-only CLI for extracting filtered transcripts from Claude Code, Codex, and Pi session files; useful for debugging, review, and piping transcripts into other tools. MIT.
 
+- **[Engine](https://github.com/StarshipSuperjam/engine-template)** `⭐ 0` — Repository-native software-engineering harness for Claude Code and Codex that helps people build and maintain real projects through persistent state and memory, deliberate build controls, unattended planned work, and evidence-backed pull requests. Source-available (Apache-2.0 + Commons Clause).
+
 ---
 
 ## Contributing


### PR DESCRIPTION
## Summary

Adds [Engine](https://github.com/StarshipSuperjam/engine-template) to the Agent infrastructure section.

## Why it fits

- Runs terminal-natively through Claude Code and Codex using `/engine-*` and `$engine-*` commands.
- The host coding agent reads and writes repositories, runs commands and tests, and prepares pull requests; Engine carries project state, memory, controls, and evidence across sessions.
- Can advance an already-planned build unattended while keeping merge authority with the operator.
- Public, active, and currently has 0 GitHub stars.
- Source-available under Apache-2.0 with the Commons Clause.

The entry is placed after the 1-star entries, following the section's descending star order.

## Validation

- Only `README.md` changes.
- `git diff --check` passes.
- The repository link, current star count, placement, and license wording were verified before submission.
