### PR TITLE
Add Meaning Assurance

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,8 @@ Multi-agent coordination, swarm patterns, and autonomous execution loops. Sorted
 
 - **[Ralph Workflow](https://github.com/Ralph-Workflow/Ralph-Workflow)** `⭐ 3` — Local-first loop runner for Claude Code/Codex CLI: executes a spec in a real git repo with `progress.json` + `resume.md` + a 3-step timeout-cap; restartable, test-feedback-driven, no hosted runtime. MIT.
 
+- **[Meaning Assurance](https://github.com/leviuszen/meaning-assurance)** `⭐ 2` — Windows-first, local file-backed governance harness for Claude Code and Reasonix: bounds tasks, isolates implementation in git worktrees, freezes review evidence, moderates adversarial findings, and leaves final acceptance to a human. PowerShell, Apache-2.0.
+
 - **[the-perfect-orchestrator](https://github.com/daman8271/the-perfect-orchestrator)** `⭐ 1` — One lead Claude Code session commands N autonomous workers in tmux panes — spawn, brief, monitor, then adversarially verify results. Pure bash + tmux, zero daemons, coordination via plain files. Also a Claude Code plugin shipping the `/orch` skill. MIT.
 
 ### Agent infrastructure


### PR DESCRIPTION
## What changed

Adds Meaning Assurance to **Orchestrators & autonomous loops**, sorted between the current 3-star and 1-star entries.

## Why

Meaning Assurance is a Windows-first, terminal-native governance harness for coding-agent work. It can launch Claude Code and Reasonix workers, isolate implementation in Git worktrees, freeze and hash review evidence, moderate adversarial findings, and keep final acceptance human-controlled.

## Project facts

- Repository: https://github.com/leviuszen/meaning-assurance
- License: Apache-2.0
- Current GitHub stars: 2
- Public release: https://github.com/leviuszen/meaning-assurance/releases/tag/v0.2.0
- Credential-free deterministic demo is included in the repository

## Validation

- Confirmed the repository is public and responds with HTTP 200
- Preserved descending star order in the section
- `git diff --check` passes