### PR TITLE
Add Engine to Agent infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,6 +667,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[Hivelore](https://github.com/Doucs91/hivelore)** `⭐ 1` — Deterministic policy gate for agent-written code: a lesson captured via MCP (`mem_tried`) becomes a validated regex/AST/test guard that Git hooks and CI use to refuse any diff reintroducing the documented mistake; briefs any agent with the team's repo-specific rules over MCP. TypeScript CLI, npm (`@hivelore/cli`). Apache-2.0.
 
+- **[Engine](https://github.com/StarshipSuperjam/engine-template)** `⭐ 0` — Repository-native software-engineering harness for Claude Code and Codex that helps people build and maintain real projects through persistent state and memory, deliberate build controls, unattended planned work, and evidence-backed pull requests. Apache-2.0.
+
 ---
 
 ## Contributing


### PR DESCRIPTION
## Summary

Adds [Engine](https://github.com/StarshipSuperjam/engine-template) to the Agent infrastructure section.

## Why it fits

- Runs terminal-natively through Claude Code and Codex using `/engine-*` and `$engine-*` commands.
- The host coding agent reads and writes repositories, runs commands and tests, and prepares pull requests; Engine carries project state, memory, controls, and evidence across sessions.
- Can advance an already-planned build unattended while keeping merge authority with the operator.
- Public, active, and currently has 0 GitHub stars.
- Apache-2.0.

The entry is placed at the end of the section, following the section's descending star order (0 stars).

## Validation

- Only `README.md` changes.
- `git diff --check` passes.
- The repository link, current star count, placement, and license wording were verified before submission.
