### PR TITLE
Add leanharness to Agent infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,6 +589,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[agent-trace](https://github.com/ertygiq/agent-trace)** `⭐ 1` — Text-only CLI for extracting filtered transcripts from Claude Code, Codex, and Pi session files; useful for debugging, review, and piping transcripts into other tools. MIT.
 
+- **[leanharness](https://github.com/bartek-890/leanharness)** `⭐ 0` — Zero-dependency `npx` installer that drops a ten-file Claude Code harness into a repo: a four-rule `CLAUDE.md`, credential deny rules, a Stop hook that refuses "done" without verification proof, and a small skill/agent kit. Sized against the instruction budget rather than filled — a published run of four hostile prompts passed 4/4 with the harness, 1/4 with none, and 3/4 with a ~300-line instruction file at ~2.4× the always-loaded tokens. Also writes `AGENTS.md`. MIT.
+
 ---
 
 ## Contributing


### PR DESCRIPTION
Adds [leanharness](https://github.com/bartek-890/leanharness) to **Harnesses & orchestration → Agent infrastructure**.

**What it is:** a zero-dependency `npx` installer that drops a ten-file Claude Code harness into a repo — a four-rule `CLAUDE.md`, credential deny rules in `settings.json`, a Stop hook that refuses "done" without verification proof, two skills, and three subagents. It also writes `AGENTS.md`, so Codex/Cursor/Gemini CLI read the same rules.

**Why it may be interesting here:** it is sized against the instruction budget rather than filled. The author published the run behind that claim — the same four hostile prompts against three setups, headless: 4/4 passed with the harness, 1/4 with no harness, 3/4 with a ~300-line instruction file that cost ~2.4× the always-loaded tokens. Write-up: [A 129-rule CLAUDE.md replied like an empty one](https://bartlomiejkrupa.dev/articles/claude-md-adherence-bench). It is an experiment, not a benchmark, and the post says so.

**Against the inclusion criteria:**
- CLI / terminal interface — yes, `npx leanharness`, no IDE requirement.
- Reads/writes code and runs commands — it writes agent-config files and installs a Stop hook that gates task completion; it is infrastructure for a coding agent rather than an agent itself, which is what this subsection collects (cf. *Project Tiny Context Harness*, *OSOP*, *Hivelore*).
- Valid, active project — v0.6.1 on npm, published 2026-07-18, ~1.2k downloads to date. MIT.

**Placement:** entries are star-sorted, and this one is at ⭐ 0 on GitHub, so I put it last in the section. Happy to move, reword, or shorten it to one line — or to close this if a 0-star entry is below the bar for the list.

Disclosure: I am the author of leanharness, and this PR was prepared with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeRAmZfDv4SyKak9ggA94X