### PR TITLE
Update Aeon entry: canonical repo + 6-harness dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ Multi-agent coordination, swarm patterns, and autonomous execution loops. Sorted
 
 - **[fractal](https://github.com/plasma-ai/fractal)** `⭐ 685` — CLI/TUI orchestrator for hierarchical agent loops, with nodes working in their own git worktrees and delegating separable subtasks to child agents. Supports Claude Code, Codex, Grok Build, OpenCode, and Oh My Pi, with configurable caps on iterations, depth, direct children, cost, and time. Apache-2.0.
 
-- **[Aeon](https://github.com/aaronjmars/aeon)** `⭐ 640` — Autonomous agent framework that runs unattended on GitHub Actions; orchestrates Claude Code across 90+ skills (research, dev, crypto, productivity) on cron or reactive triggers, with quality scoring (1–5 via Haiku), persistent memory, and a self-healing loop. MCP + A2A integrations. MIT.
+- **[Aeon](https://github.com/aeonfun/aeon)** `⭐ 640` — Autonomous agent framework that runs unattended on GitHub Actions; dispatches skills to six coding-agent harnesses behind one Claude-Code-shaped contract (Claude Code, Grok, Codex, Pi, Vibe, Kimi) on cron or reactive triggers, with quality scoring (1-5 via Haiku), git-persisted memory, a self-healing loop that rewrites underperforming skills, and an MCP server exposing every skill as a tool. 60+ skills across research, dev, crypto, and productivity. MIT.
 
 - **[h5i](https://github.com/h5i-dev/h5i)** `⭐ 510` — Runs several coding agents (Claude Code, Codex) on the same task in isolated sandboxes, has them peer-review each other, then a neutral verifier replays and tests each candidate and merges the one that passes. Run metadata is versioned in the repo under `refs/h5i/*`. Apache-2.0.
 


### PR DESCRIPTION
Two fixes to the existing Aeon entry:

1. **Canonical repo.** The link pointed at `aaronjmars/aeon`, which is now a redirect repo. The canonical repository moved to [`aeonfun/aeon`](https://github.com/aeonfun/aeon) (owner: Aeon Inc). Updated the link (and the stars badge where present) to the canonical repo.

2. **Accuracy.** Refreshed the description to match what ships on `main` today:
   - Aeon dispatches skills to **six coding-agent harnesses behind one contract** - Claude Code, Grok, Codex, Pi, Vibe, and Kimi (via its `harness-adapter`), not Claude Code alone. This is the framework's main differentiator.
   - Added the **MCP server** (`apps/mcp-server`) that exposes every skill as an MCP tool.
   - Dropped the "A2A" claim: there is no A2A agent card or endpoint in the repo, so the previous "MCP + A2A integrations" wording was inaccurate.
   - Corrected the skill count (60+ unique skills across core + packs; the earlier "90+" was high).

Disclosure: I work on Aeon. Happy to adjust wording or placement to fit the list's conventions.
