### PR TITLE
Add fab-kit (Orchestrators & autonomous loops)

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,8 @@ Multi-agent coordination, swarm patterns, and autonomous execution loops. Sorted
 
 - **[5dive](https://github.com/5dive-ai/5dive)** `⭐ 35` — Run a company of AI coding agents on a server you own: one-command spin-up of named agents (Claude Code, Codex, Grok, and more), cron + heartbeat scheduling, multi-agent orchestration, Telegram control, and a babysit + needs-you triage dashboard. Self-hosted. MIT.
 
+- **[fab-kit](https://github.com/sahil87/fab-kit)** `⭐ 28` — Spec-driven development workflow for AI coding agents: an intake → plan → apply → review → hydrate pipeline with confidence gating, per-stage model tiers, a multi-agent operator mode over tmux, and cross-harness dispatch (Claude Code, Codex, Gemini). MIT.
+
 - **[agx](https://github.com/ramarlina/agx)** `⭐ 26` — Checkpoint-based execution engine for AI coding agents; durable Wake→Work→Sleep loops that resume instantly across sessions. Supports Claude Code, Codex CLI, Gemini CLI, and Ollama. CLI + web dashboard + macOS app.
 
 - **[Galley](https://github.com/shinpr/galley)** `⭐ 16` — Local-first runtime for supervised AI coding tasks: isolated git worktrees, supervisor review against acceptance criteria, retry/escalate loops, on-disk run evidence, and PR handoff. Supports Codex CLI and Claude Code. Go, MIT.


### PR DESCRIPTION
Adds [fab-kit](https://github.com/sahil87/fab-kit) (⭐ 28, MIT) — spec-driven development workflow for AI coding agents: an intake → plan → apply → review → hydrate pipeline with confidence gating, per-stage model tiers, a multi-agent operator mode over tmux, and cross-harness dispatch (Claude Code, Codex, Gemini).

Placed star-sorted in **Orchestrators & autonomous loops** (between 5dive 35 and agx 26).