### PR TITLE
Add agents-cli to Session managers & parallel runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,8 @@ Tools for running and managing multiple agent sessions side-by-side. Sorted by G
 
 - **[Claudescope](https://github.com/vladar107/claudescope)** `⭐ 14` — Local, read-only CLI that serves a web UI to browse, search, and analyze AI coding-agent transcripts across Claude Code, Codex, Junie, pi, opencode, and Copilot CLI — sessions merged by working directory, with full-text search and token-cost analytics. npm, cross-platform. MIT.
 
+- **[agents-cli](https://github.com/phnx-labs/agents-cli)** `⭐ 14` — CLI to install, version-pin, and run many coding-agent harnesses (Claude Code, Codex, Gemini CLI, Cursor, OpenCode, Grok, …); shared skills/MCP/rules, multi-agent teams, session index, and SSH fleet dispatch. npm `@phnx-labs/agents-cli`. Apache-2.0.
+
 - **[multi-agent-workflow-kit](https://github.com/laris-co/multi-agent-workflow-kit)** `⭐ 11` — Orchestrate parallel AI agents in isolated git worktrees with shared tmux visibility.
 
 - **[CLITrigger](https://github.com/HyperAITeam/CLITrigger)** `⭐ 11` — Self-hosted web UI for orchestrating Claude Code, Codex, and Gemini CLIs in parallel git worktrees. Features multi-agent discussion mode (architect/developer/reviewer debate before implementation), cross-project Morning Review Queue, scheduled execution with rate-limit auto-recovery, and a built-in Git client. MIT.


### PR DESCRIPTION
## What

Add [agents-cli](https://github.com/phnx-labs/agents-cli) under **Harnesses & orchestration → Session managers & parallel runners**, sorted by stars next to Claudescope (`⭐ 14`).

## Why

agents-cli is a terminal CLI that installs and version-pins coding-agent harnesses (Claude Code, Codex, Gemini CLI, Cursor, OpenCode, Grok, and peers), syncs shared skills/MCP/rules, and runs multi-agent teams, session history, and SSH fleet dispatch from one surface. Fits this section next to session managers and multi-agent runners (Claude Squad, agent-of-empires, showagent).

- Repo: https://github.com/phnx-labs/agents-cli
- npm: `@phnx-labs/agents-cli`
- License: Apache-2.0
- Stars (live `gh api`): **14**
