### PR TITLE
Add Agent Autopilot to Orchestrators & autonomous loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,8 @@ Multi-agent coordination, swarm patterns, and autonomous execution loops. Sorted
 
 - **[the-perfect-orchestrator](https://github.com/daman8271/the-perfect-orchestrator)** `⭐ 1` — One lead Claude Code session commands N autonomous workers in tmux panes — spawn, brief, monitor, then adversarially verify results. Pure bash + tmux, zero daemons, coordination via plain files. Also a Claude Code plugin shipping the `/orch` skill. MIT.
 
+- **[Agent Autopilot](https://github.com/Scn64/agent-autopilot)** `⭐ 0` — Governance and continuity scaffolding for Claude Code agents that run unattended for months: a standing-orders constitution re-read every session, an append-only decision log plus state snapshot so a later session knows what an earlier one settled, and a human approval gate for money, credentials, and public actions. Scheduler-agnostic plain files. MIT.
+
 ### Agent infrastructure
 
 Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by GitHub stars.


### PR DESCRIPTION
Adding **[Agent Autopilot](https://github.com/Scn64/agent-autopilot)** (MIT) to *Harnesses & orchestration â†’ Orchestrators & autonomous loops*.

**Disclosure: this is my own project.**

It is the governance layer for a Claude Code agent that runs unattended on a schedule for months: a standing-orders constitution the agent re-reads every session, an append-only decision log and state snapshot so a later session knows what an earlier one already settled, and a hard human-approval gate for money, credentials, and anything public.

Two things worth flagging so you can judge the fit honestly:

- It is **plain files in a folder**, not a binary â€” there is no CLI of its own. It shapes what a terminal agent (Claude Code) is, remembers, and is allowed to do, which is why I filed it under harnesses rather than agents. If that puts it outside your "must have a CLI or terminal interface" bar, no hard feelings â€” close it.
- It has **0 stars**. It is new. I placed it last in the section per your star sort.

It is extracted from a real system: the scaffolding runs a live autonomous agent daily, and the repo is the generalized core of it.