### PR TITLE
Add intentic (self-hosted parallel agent workspace)

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,8 @@ Tools for running and managing multiple agent sessions side-by-side. Sorted by G
 
 - **[iris](https://github.com/itzenata/iris-tui)** `⭐ 5` — Live TUI supervisor for every active Claude Code session: status, tokens, estimated cost, and one-pane approval of pending tool calls via a PreToolUse hook. Rust, MIT.
 
+- **[intentic](https://github.com/intentic/intentic)** `⭐ 3` — Self-hosted workspace for running terminal coding agents in parallel: Claude Code, Codex, Grok and Kimi Code natively, plus OpenCode, Gemini CLI and any other ACP agent. Each agent gets its own Docker container and git worktree on your own hardware; terminals survive disconnects, any browser or phone reopens the same fleet, and changes land through per-file, per-hunk diff review. Ships an `ic` CLI and a Tauri desktop app. TypeScript, MIT.
+
 - **[Agent CLI Menu](https://github.com/roypadina/AgentCliMenu)** `⭐ 2` — macOS TUI and menu-bar app to start or resume Claude Code and Codex sessions; frecency project launcher plus full-transcript fuzzy search across past sessions, with a working-directory confidence gate. MIT.
 
 - **[postmortemthis](https://github.com/Softeria/postmortemthis)** `⭐ 1` — Runs every coding-agent CLI you have (Claude Code, Codex, Gemini, Qwen, Vibe) in parallel and read-only over your diff, then synthesizes their reviews into one ship / no-ship verdict. A cross-model second opinion before you ship. MIT.


### PR DESCRIPTION
Adds **intentic** to *Harnesses & orchestration → Session managers & parallel runners*, placed by star count
(3, between `iris` at 5 and `Agent CLI Menu` at 2).

**Inclusion requirements**

- *CLI or terminal interface* — ships an `ic` CLI (prebuilt binaries for macOS, Linux and Windows in every
  release) that provisions and drives sandboxes, and each sandbox runs real terminals over PTY; the agents it
  runs are the terminal-native ones (Claude Code, Codex, OpenCode, Gemini CLI over ACP).
- *Reads/writes code and runs commands autonomously* — agents work in a real checkout in their own git
  worktree, run builds and tests in their container, and propose changes as diffs.
- *Valid, active project* — released continuously, MIT, TypeScript.

**Why it's interesting for this section:** isolation is per agent rather than per thread — a container plus a
git worktree each, so ten parallel runs never see each other's tree — and the sandbox image is an editable
Dockerfile the user approves rather than a fixed environment. Runs continue when you disconnect, and the same
fleet reopens from any browser or a phone.

Disclosure: I maintain intentic.
