### PR TITLE
Add Boost to Agent infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[Coasts](https://github.com/coast-guard/coasts)** `⭐ 421` — Containerized host orchestration for git worktrees; isolates ports, networks, and services per environment using DinD/Sysbox/Podman. MIT.
 
+- **[Boost](https://github.com/jfrog/boost)** `⭐ 408` — Free [public-preview](https://boost.jfrog.com/) CLI that filters terminal and CI output before it reaches Cursor, Claude Code, or Codex, typically reducing log tokens by 60–90%, with reversible retrieval and local performance reports.
+
 - **[subtask](https://github.com/zippoxer/subtask)** `⭐ 339` — Claude Skill for delegating tasks with subagents in Git worktrees.
 
 - **[claude-cmd](https://github.com/kiliczsh/claude-cmd)** `⭐ 313` — Terminal wrapper for interacting with Claude models; often used as a building block in harness scripts.


### PR DESCRIPTION
## Summary

Adds [Boost](https://github.com/jfrog/boost) to **Agent infrastructure**, sorted at its current 408-star position.

## Why it fits

Boost is a free CLI that sits at the shell boundary for Cursor, Claude Code, and Codex. It filters terminal and CI output before it enters model context, typically reducing log tokens by 60–90%, while keeping hidden output recoverable and reporting local command performance.

- Free public preview: https://boost.jfrog.com/
- Active public repository with 408 stars
- CLI and agent-hook integrations

## Validation

- Only `README.md` changes.
- `git diff --check` passes.
- Links and current star count were verified before submission.

Disclosure: I work on Boost at JFrog.