### PR TITLE
Add flameox to Agent infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,6 +577,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[OSOP](https://github.com/Archie0125/osop-agent-rules)** `⭐ 5` — Universal workflow logging protocol for CLI coding agents; produces `.osop` workflow definitions and `.osoplog.yaml` execution records. Supports Claude Code, Codex, Cursor, Windsurf, Aider, Cline, Roo Code, Devin, and OpenClaw. Includes a [visual editor](https://osop-editor.vercel.app) and [spec](https://github.com/Archie0125/osop-spec).
 
+- **[flameox](https://github.com/morluto/flameox)** `⭐ 4` — CLI and MCP profiling toolkit that lets agents capture reproducible runtime evidence, compare runs, and investigate compiled services, GPU kernels, and inference workloads.
+
 - **[Project Tiny Context Harness](https://github.com/Seven128/project-tiny-context-harness)** `⭐ 3` — Minimal repo-native project memory for CLI coding agents. Installs `AGENTS.md`, `project_context/**`, role Skills, and a `validate-context` gate so Codex, Claude Code, Cursor, Gemini CLI, OpenCode, and similar agents can recover project intent, boundaries, and validation paths across fresh sessions. MIT.
 
 - **[linear-cli](https://github.com/phnx-labs/linear-cli)** `⭐ 2` — Single-file Python CLI for Linear (the issue tracker), zero dependencies. Designed for use as a subagent tool by Claude Code, Codex, Gemini, or Cursor; ships a SKILL.md for drop-in Claude Code integration. MIT.


### PR DESCRIPTION
Adds flameox to Agent infrastructure at its current GitHub star-count position.

flameox gives agents bounded CLI and MCP operations to run named profiling workloads, preserve evidence, compare runs, and investigate compiled-service, GPU-kernel, and inference-workload performance.

Validation: `git diff --check`.