### PR TITLE
Add stratless (Agent infrastructure)

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,6 +591,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 ---
 
+- **[stratless](https://github.com/stratless-ai/stratless)** — Derives skills for Claude Code and Codex from the user's own session history: measures what recurs locally, the user's own assistant proposes the skills, every skill cites the evidence counts that earned it. MIT, zero runtime deps, nothing leaves the machine.
+
 ## Contributing
 
 PRs welcome! To add an entry, please ensure it meets these criteria:


### PR DESCRIPTION
Adds stratless under Agent infrastructure: a free MIT CLI that derives skills for Claude Code and Codex from the user's own session history — measured locally, proposals from the user's own assistant, every skill citing the evidence counts that earned it. Meets the criteria: CLI interface, actively developed, reads history and writes skill files autonomously (on explicit consent). Placed at section end per star sorting (new repo). Disclosure: I'm the author.