### PR TITLE
Add Atomic Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ Forkable, extensible, and community-driven. Sorted by GitHub stars. Provider tag
 
 - **[Amazon Q Developer CLI](https://github.com/aws/amazon-q-developer-cli)** `⭐ 2k` `[AWS]` — AWS's agentic terminal chat for building apps, debugging, and DevOps with natural language. Apache-2.0.
 
+- **[Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent)** `⭐ 1.8k` `[AtomicBot-ai]` — Local-first CLI and TUI coding agent that runs open-weight models entirely on your machine through a llama.cpp fork; no account or API key required. React/ink TUI, 56 built-in tools (browser, filesystem, git, memory, vision), MCP support, and a five-layer local memory system. macOS/Linux/Windows. MIT.
+
 - **[Neovate Code](https://github.com/neovateai/neovate-code)** `⭐ 1.6k` `[Ant Group]` — Ant Group's CLI agent with plugin system, multi-model/multi-provider support, MCP integrations, and headless automation mode. MIT.
 
 - **[VT Code](https://github.com/vinhnx/vtcode)** `⭐ 798` — Open-source coding agent with LLM-native code understanding and robust shell safety. Supports multiple LLM providers with automatic failover and efficient context management. MIT.


### PR DESCRIPTION
Hi! I'm the CPO of Atomic Agent. Thanks so much for putting this list together, it's a genuinely useful map of the space, and our team would be thrilled to be part of it.

I've added **Atomic Agent** to the **Open Source** section, in its star-sorted slot (between Amazon Q Developer CLI and Neovate Code). I tried to match the existing row format exactly: name + GitHub link, star badge, provider tag, and a one-paragraph description with the license at the end.

**What it is:** a local-first CLI and TUI coding agent. It runs open-weight models entirely on your machine through a llama.cpp fork, with no account or API key required to install or run. The TUI is built on React and ink. It ships 56 built-in tools (browser, filesystem, git, memory, vision), supports MCP (Model Context Protocol), and has a five-layer local memory system. Cross-platform: macOS, Linux, and Windows.

**Quick facts for review:**
- Repo: https://github.com/AtomicBot-ai/atomic-agent (MIT, active, maintained by the AtomicBot-ai organization)
- Website: https://atomicagent.io
- Docs: https://atomicagent.io/docs
- Install: `curl -fsSL https://atomicagent.io/install | sh`
- X: https://x.com/atomicagent_io
- Discord: https://discord.gg/Us7qXtDGw

It meets the inclusion requirements: it has a CLI and terminal interface, it reads/writes code and runs commands autonomously, and the repo is valid and active.

Happy to adjust the wording, tag, or placement to fit your conventions. Thanks again for maintaining this!
