### PR TITLE
Add Martty terminal agent client

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Forkable, extensible, and community-driven. Sorted by GitHub stars. Provider tag
 
 - **[CLAII](https://github.com/agencyswarm/CLAII)** `⭐ 4` — CLI-first AI coding agent with multi-agent orchestration, MCP toolchains, and memory-persistent refactors.
 
-- **[DeepSeek Build (dsh-tui)](https://github.com/openma-ai/deepseek-harness-tui)** `⭐ 1` — Rust/ratatui terminal coding client for DeepSeek Harness that consumes the SDK JSON-RPC event stream directly; shows streamed reasoning, tool calls, subagents, and token usage, and runs standalone or as a `dsh` profile bundle. MIT.
+- **[Martty](https://github.com/openma-ai/Martty)** `⭐ 48` — DSH-first Rust/ratatui agent TUI with streamed reasoning, tool calls, subagents, token usage, durable sessions, and a Cordis-extensible client UI; runs standalone or as a `dsh` profile bundle. MIT.
 
 ### OpenClaw ecosystem
 

--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ Forkable, extensible, and community-driven. Sorted by GitHub stars. Provider tag
 
 - **[CLAII](https://github.com/agencyswarm/CLAII)** `⭐ 4` — CLI-first AI coding agent with multi-agent orchestration, MCP toolchains, and memory-persistent refactors.
 
+- **[DeepSeek Build (dsh-tui)](https://github.com/openma-ai/deepseek-harness-tui)** `⭐ 1` — Rust/ratatui terminal coding client for DeepSeek Harness that consumes the SDK JSON-RPC event stream directly; shows streamed reasoning, tool calls, subagents, and token usage, and runs standalone or as a `dsh` profile bundle. MIT.
+
 ### OpenClaw ecosystem
 
 Projects built on, forked from, or inspired by [OpenClaw](https://github.com/openclaw/openclaw) — the open-source personal AI assistant. Sorted by GitHub stars.


### PR DESCRIPTION
Adds Martty, formerly `deepseek-harness-tui`, as a terminal coding-agent client for DeepSeek Harness.

This updates the existing open submission to the current project name, canonical repository URL, and feature description.
