### PR TITLE
Add context-bridge (session handoff across five agent CLIs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,8 @@ Multi-agent coordination, swarm patterns, and autonomous execution loops. Sorted
 
 - **[Ralph Workflow](https://github.com/Ralph-Workflow/Ralph-Workflow)** `⭐ 3` — Local-first loop runner for Claude Code/Codex CLI: executes a spec in a real git repo with `progress.json` + `resume.md` + a 3-step timeout-cap; restartable, test-feedback-driven, no hosted runtime. MIT.
 
+- **[context-bridge](https://github.com/serdardb/context-bridge)** `⭐ 3` — Hands a live coding session from one agent to another without losing the thread: each agent keeps its own native session, and the bridge transfers only the context the other one is missing. `/bridge codex` inside Claude Code, `$bridge claude` inside the rest; five agents (Claude Code, Codex, Grok, Antigravity, OpenCode) in any of twenty directions, with lanes for parallel lines of work in one repo and `bridge handoff --from` to rebuild a delta from a dead agent's transcript. No API keys — it drives the subscription-authenticated CLIs you already have. Node, npm `@serdardb/context-bridge`, MIT.
+
 - **[the-perfect-orchestrator](https://github.com/daman8271/the-perfect-orchestrator)** `⭐ 1` — One lead Claude Code session commands N autonomous workers in tmux panes — spawn, brief, monitor, then adversarially verify results. Pure bash + tmux, zero daemons, coordination via plain files. Also a Claude Code plugin shipping the `/orch` skill. MIT.
 
 ### Agent infrastructure


### PR DESCRIPTION
Adding **[context-bridge](https://github.com/serdardb/context-bridge)** — a CLI that hands a live coding session from one agent to another without losing the thread. Each agent keeps its own native session; the bridge remembers which sessions belong to the same project and transfers only the context the other agent is missing.

It does not replace or proxy any agent, and needs no API keys — it drives the subscription-authenticated CLIs already installed.

**Against the inclusion criteria**

- CLI/terminal interface — `bridge`, plus `/bridge <agent>` inside Claude Code and `$bridge <agent>` inside the others
- Reads/writes and runs commands autonomously — it launches the agents, reads their session stores and transcripts, and writes deltas into them through hooks (OpenCode has neither hook nor promptable resume, so it writes into the session database directly)
- Active — 0.12.2 published 8 days ago, 343 tests green on ubuntu+macOS × Node 18/20/22

**Placement**

Put in *Orchestrators & autonomous loops*, directly above `the-perfect-orchestrator` to keep the section's star order (⭐ 3).

I chose that section because [Claudexor](https://github.com/razzant/claudexor) is there and solves the same problem from the other direction — it keeps one thread across harnesses by rotating accounts behind a control plane, this keeps one thread by moving the context between each harness's own session. *Session managers & parallel runners* would also be defensible; happy to move it if you would rather it sat there, since the handoff is sequential rather than side-by-side.

Five agents today — Claude Code, Codex, Grok, Antigravity, OpenCode — in any of the twenty directions.