### PR TITLE
Add Lians portable agent memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,6 +653,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[Terminai](https://github.com/emosenkis/terminai)** `⭐ 6` — Makes your terminal of choice AI-enabled using your favorite CLI coding agent. Completely transparent until you activate the AI with Ctrl-Space, then runs your agent in an overlay with access to your terminal.
 
+- **[Lians](https://github.com/Lians-ai/Lians)** `⭐ 6` — Apache-2.0 portable memory for Claude, Codex, Cursor, and other MCP coding agents; runs locally with SQLite and no account, with bounded recall plus inspect, correct, and forget controls across sessions and tools.
+
 - **[OSOP](https://github.com/Archie0125/osop-agent-rules)** `⭐ 5` — Universal workflow logging protocol for CLI coding agents; produces `.osop` workflow definitions and `.osoplog.yaml` execution records. Supports Claude Code, Codex, Cursor, Windsurf, Aider, Cline, Roo Code, Devin, and OpenClaw. Includes a [visual editor](https://osop-editor.vercel.app) and [spec](https://github.com/Archie0125/osop-spec).
 
 - **[Project Tiny Context Harness](https://github.com/Seven128/project-tiny-context-harness)** `⭐ 3` — Minimal repo-native project memory for CLI coding agents. Installs `AGENTS.md`, `project_context/**`, role Skills, and a `validate-context` gate so Codex, Claude Code, Cursor, Gemini CLI, OpenCode, and similar agents can recover project intent, boundaries, and validation paths across fresh sessions. MIT.


### PR DESCRIPTION
## What changed

- add Lians to the Agent infrastructure section at its current 6-star position
- describe only its public, working local-memory capabilities for MCP coding agents

## Why

The directory already includes coding-agent memory infrastructure such as Vestige, GoodMemory, and Agent Memory System. Lians is a distinct Apache-2.0 option for portable memory across Claude, Codex, Cursor, and other MCP agents, so it fits this section without being presented as a standalone coding agent.

## User impact

Readers looking for local cross-session memory can discover a SQLite-backed option with bounded recall and explicit inspect, correct, and forget controls.

## Validation

- `git diff --check`
- verified the linked repository is public, active, Apache-2.0, and currently has 6 stars
- confirmed there is no existing Lians entry or pull request in this repository