### PR TITLE
Add SandBase Harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,8 @@ Multi-agent coordination, swarm patterns, and autonomous execution loops. Sorted
 
 - **[Aeon](https://github.com/aeonfun/aeon)** `⭐ 653` — Autonomous agent framework that runs unattended on GitHub Actions; dispatches skills to six coding-agent harnesses behind one Claude-Code-shaped contract (Claude Code, Grok, Codex, Pi, Vibe, Kimi) on cron or reactive triggers, with quality scoring (1–5 via Haiku), git-persisted memory, a self-healing loop that rewrites underperforming skills, and an MCP server exposing every skill as a tool. 60+ skills across research, dev, crypto, and productivity. MIT.
 
+- **[SandBase Harness](https://github.com/sandbaseai/sandbase-harness)** `⭐ 576` — Model-agnostic local agent runtime with CLI/API/console surfaces, built-in file and shell tools, persistent sessions, and per-session local, Docker, Kubernetes, or self-hosted sandboxes. Auditable event history, replay, MCP integration, and a native DeepSeek Harness bundle. Apache-2.0.
+
 - **[h5i](https://github.com/h5i-dev/h5i)** `⭐ 527` — Runs several coding agents (Claude Code, Codex) on the same task in isolated sandboxes, has them peer-review each other, then a neutral verifier replays and tests each candidate and merges the one that passes. Run metadata is versioned in the repo under `refs/h5i/*`. Apache-2.0.
 
 - **[Claudexor](https://github.com/razzant/claudexor)** `⭐ 404` — Local-first control plane that keeps one coding thread across Claude Code, Codex, Cursor, and OpenCode. It can connect multiple user-owned accounts of the same harness (for example, five Claude Code accounts or ten Codex accounts), track each account's quota, and opt in to automatic rotation when one reaches its limit. CLI + macOS app. MIT.


### PR DESCRIPTION
## What changed

Added SandBase Harness to **Harnesses & orchestration**, sorted between the 653- and 527-star entries.

## Why it qualifies

- Provides a CLI plus API and local console surfaces.
- Its agents use built-in file and shell tools to work in repositories and run commands.
- Implements persistent sessions and local, per-session Docker, Kubernetes, and self-hosted sandbox backends.
- Adds audit/replay, MCP integration, and a native DeepSeek Harness bundle.
- Active Apache-2.0 repository with 576 stars at submission time.

## Validation

- `git diff --check`
- `python3 -m py_compile scripts/update-stars.py`
