### PR TITLE
Add Sudarshan (Orchestrators & autonomous loops)

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,8 @@ Multi-agent coordination, swarm patterns, and autonomous execution loops. Sorted
 
 - **[the-perfect-orchestrator](https://github.com/daman8271/the-perfect-orchestrator)** `⭐ 1` — One lead Claude Code session commands N autonomous workers in tmux panes — spawn, brief, monitor, then adversarially verify results. Pure bash + tmux, zero daemons, coordination via plain files. Also a Claude Code plugin shipping the `/orch` skill. MIT.
 
+- **[Sudarshan](https://github.com/Suraj1235/sudarshan-superharness)** `⭐ 1` — Provider-neutral build harness that drives any LLM API or agent CLI from an idea/PRD/spec to verification-gated completion: explainable cost estimates before spending, immutable plans, atomic checkpoints with kill-and-resume durability, and budget/policy enforcement the model cannot weaken. Zero-dependency Python, MIT.
+
 ### Agent infrastructure
 
 Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by GitHub stars.


### PR DESCRIPTION
Adds **[Sudarshan](https://github.com/Suraj1235/sudarshan-superharness)** to *Harnesses & orchestration → Orchestrators & autonomous loops*.

**Inclusion criteria:**
- CLI interface: `sudarshan estimate / build / status / input / resume` (Python entry point, zero runtime dependencies)
- Reads/writes code and runs commands autonomously: durable JSON action loop with workspace-confined file tools and policy-bounded subprocess execution
- Active project: MIT-licensed, CI on Ubuntu/macOS/Windows (Python 3.9 and 3.13), 165 tests passing, with a public end-to-end acceptance artifact ([ORBIT SHIFT](https://github.com/Suraj1235/orbit-shift)) built and verified through the harness

**Format:** star count included, placed last in the section per star-count sorting (⭐ 1).