### PR TITLE
Add hax to open-source terminal agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 A curated list of **110+ CLI coding agents** — AI-powered tools that live in your terminal, read/edit repos, and run commands — plus the **harnesses** that orchestrate, sandbox, or extend them.
 
-> **Last updated:** 2026-08-13
+> **Last updated:** 2026-08-16
 
 ### What is a CLI coding agent?
 
@@ -168,6 +168,8 @@ Forkable, extensible, and community-driven. Sorted by GitHub stars. Provider tag
 - **[zot](https://github.com/patriceckhart/zot)** `⭐ 313` — Zero-overhead and lightweight coding agent harness with TUI/JSON/RPC modes, structured tools, reviewable file diffs, skills, extensions, and optional guardrails.
 
 - **[Mini-Kode](https://github.com/minmaxflow/mini-kode)** `⭐ 305` — An educational AI coding agent CLI, intended as a readable reference implementation.
+
+- **[hax](https://github.com/OleksandrChekhovskyi/hax)** `⭐ 227` — Minimalist terminal-native coding agent written in C; a single native binary that uses a few MBs of RAM and starts instantly. First-class llama.cpp support (auto-discovers the served model and its capabilities) alongside OpenAI/Anthropic-compatible endpoints, Codex, and OpenRouter. Linux/macOS/BSD, MIT.
 
 - **[nori-cli](https://github.com/tilework-tech/nori-cli)** `⭐ 166` — Multi-provider CLI built on Codex CLI; switch between Claude, Gemini, and Codex from the same native terminal.
 


### PR DESCRIPTION
Adds **hax** to *Terminal-native coding agents → Open Source*.

Website: https://usehax.dev/
GitHub repo: https://github.com/OleksandrChekhovskyi/hax

**hax** is a minimalist terminal-native coding agent written in C: a single native binary that starts instantly and uses a few MBs of RAM, so a local model on the same machine keeps the rest. llama.cpp is a first-class provider — point it at a running `llama-server` and it auto-discovers the served model and its runtime capabilities, no provider config block needed — and it also speaks OpenAI-compatible, Anthropic-compatible, Codex (ChatGPT subscription), and OpenRouter endpoints. Linux, macOS, and the BSDs; MIT.

**Placement:** sorted by stars (⭐ 227 at time of writing), between Mini-Kode (305) and nori-cli (166). Entry format follows the existing list style and parses cleanly with `scripts/update-stars.py`.

Disclosure: I'm the author of hax.
