### PR TITLE
Add Kolega Code to Open Source coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ Forkable, extensible, and community-driven. Sorted by GitHub stars. Provider tag
 
 - **[Binharic](https://github.com/CogitatorTech/binharic-cli)** `⭐ 18` — A multi-provider "tech-priest persona" coding agent CLI (stylized, tool-using).
 
+- **[Kolega Code](https://github.com/kolega-ai/kolega-code)** `⭐ 15` — Python terminal coding agent where the model writes its own multi-agent workflows (Gigacode); journaled resume replays unchanged calls free; 15+ providers, MCP, browser agent. Apache-2.0.
+
 - **[Darce](https://github.com/AmerSarhan/darce-cli)** `⭐ 9` — Ultralight (14 kB) multi-model CLI agent built with Ink; 7 tools, smart model routing across providers, streaming, session resume, and slash commands. MIT.
 
 - **[Forge (Norvia Labs)](https://github.com/NorviaLabs/forge)** `⭐ 6` — Rust TUI coding agent unifying an AI agent, a vim-style code editor, and a shell in one keyboard-driven workspace; approval-aware command execution, durable SQLite session journal, and MCP server support. MIT.


### PR DESCRIPTION
# Add Kolega Code to Open Source coding agents

Adds Kolega Code to the Open Source section under Terminal-native coding agents, positioned by star count per the contributing rules.

Kolega Code is a Python terminal coding agent where the model writes its own multi-agent workflows (Gigacode). The runtime enforces concurrency caps and token budgets, journals every completed agent call to disk, and replays unchanged calls for free on resume. It runs 15+ model providers, connects to MCP servers over streamable HTTP, SSE, and stdio, and includes a browser agent. Apache-2.0, actively developed with a docs site and CI.

Meets the inclusion requirements: CLI/terminal interface, autonomous read/write and command execution, valid active repository.
