### PR TITLE
Add aimux to Session managers & parallel runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,8 @@ Tools for running and managing multiple agent sessions side-by-side. Sorted by G
 
 - **[postmortemthis](https://github.com/Softeria/postmortemthis)** `⭐ 1` — Runs every coding-agent CLI you have (Claude Code, Codex, Gemini, Qwen, Vibe) in parallel and read-only over your diff, then synthesizes their reviews into one ship / no-ship verdict. A cross-model second opinion before you ship. MIT.
 
+- **[aimux](https://github.com/uhuntu/aimux)** `⭐ 0` — Tiny, dependency-free CLI wrapper unifying Claude Code, Codex CLI, and Kimi CLI: normalizes flags across the three tools, plus a cross-tool numbered session list, resume-by-row-number, and an LLM-judged topic search that finds relevant past sessions by content, not just exact keyword match. Single Python package, no daemon. MIT.
+
 - **[PATAPIM](https://patapim.ai)** — Terminal IDE with a 9-terminal grid for running multiple CLI coding agents simultaneously; features AI state detection, built-in Whisper voice dictation, LAN remote access, and an embedded MCP browser. Built with Electron and node-pty. Freemium.
 
 - **[Bwee](https://bwee.app)** — Desktop app for CLI coding agents where users build their own views (BYOUI) — custom tools and dashboards that live alongside the terminal. Persistent sessions and task management. macOS.


### PR DESCRIPTION
Adds [aimux](https://github.com/uhuntu/aimux), a tiny dependency-free CLI wrapper unifying Claude Code, Codex CLI, and Kimi CLI: normalized flags across the three tools, a cross-tool numbered session list (`ai full`), resume-by-row-number, and an LLM-judged topic search (`ai search`) that finds relevant past sessions by content rather than exact keyword match.

Meets the inclusion requirements: CLI/terminal interface, GitHub repo is active, entry placed by star count (0, right after postmortemthis and before the non-GitHub entries).