### PR TITLE
Add EMRG to Open Source terminal-native coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Forkable, extensible, and community-driven. Sorted by GitHub stars. Provider tag
 - **[Forge (Norvia Labs)](https://github.com/NorviaLabs/forge)** `⭐ 5` — Rust TUI coding agent unifying an AI agent, a vim-style code editor, and a shell in one keyboard-driven workspace; approval-aware command execution, durable SQLite session journal, and MCP server support. MIT.
 
 - **[CLAII](https://github.com/agencyswarm/CLAII)** `⭐ 4` — CLI-first AI coding agent with multi-agent orchestration, MCP toolchains, and memory-persistent refactors.
+- **[EMRG](https://github.com/argszero/emrg)** `⭐ 3` — Terminal-native AI coding agent (TUI + persistent background daemon) that improves its own source code: every `/rant` feedback item becomes a tested, merged PR via its evolution cycle. MIT.
 
 ### OpenClaw ecosystem
 


### PR DESCRIPTION
Adds [EMRG](https://github.com/argszero/emrg) to the **Terminal-native coding agents → Open Source** section.

**Inclusion criteria:**
- CLI/terminal interface: ✅ TUI frontend (`emrg`), backed by a persistent background daemon (`emrgd`) you can reconnect to
- Reads/writes code and runs commands autonomously: ✅ read/write/edit/bash tools, session memory, `/` autocomplete
- Valid, active project: ✅ MIT-licensed (Python 3.11+), latest release v0.2.51 (2026-08-18), CI passing

**Why it's interesting:** EMRG's evolution cycle improves its own source code — every `/rant` feedback item becomes a tested, merged PR (pytest + import check gate, rollback on failure). Self-improvement as the core differentiator, not a bolt-on.

Entry placed at the end of the Open Source section (sorted by stars, 3★).