### PR TITLE
Add awesome-claude-code-hooks to agent infrastructure list

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,6 +667,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[Hivelore](https://github.com/Doucs91/hivelore)** `⭐ 1` — Deterministic policy gate for agent-written code: a lesson captured via MCP (`mem_tried`) becomes a validated regex/AST/test guard that Git hooks and CI use to refuse any diff reintroducing the documented mistake; briefs any agent with the team's repo-specific rules over MCP. TypeScript CLI, npm (`@hivelore/cli`). Apache-2.0.
 
+- **[awesome-claude-code-hooks](https://github.com/loqimean/awesome-claude-code-hooks)** — New curated list of hooks, guides, and example scripts for Claude Code's hook system (PreToolUse, PostToolUse, SessionStart, Notification, Stop, and more).
+
 ---
 
 ## Contributing


### PR DESCRIPTION
Adds a link to https://github.com/loqimean/awesome-claude-code-hooks in the Agent infrastructure section.

It's a curated list of hooks, guides, and example scripts for Claude Code's hook system (PreToolUse, PostToolUse, SessionStart, Notification, Stop, etc). Seemed like a good fit next to the other hook/plugin related entries in that section.

Happy to adjust placement or wording if you want it somewhere else.