### PR TITLE
Add Claude KISS to agent infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,6 +667,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[Hivelore](https://github.com/Doucs91/hivelore)** `⭐ 1` — Deterministic policy gate for agent-written code: a lesson captured via MCP (`mem_tried`) becomes a validated regex/AST/test guard that Git hooks and CI use to refuse any diff reintroducing the documented mistake; briefs any agent with the team's repo-specific rules over MCP. TypeScript CLI, npm (`@hivelore/cli`). Apache-2.0.
 
+- **[Claude KISS](https://github.com/aphoristicartist/claude-kiss)** `⭐ 1` — Transparent POSIX shell launcher that narrows Claude Code's default prompt and tool surface while preserving its native binary, account, and sessions; web, skills, delegation, and MCP are opt-in. MIT.
+
 ---
 
 ## Contributing


### PR DESCRIPTION
## Summary

Add [Claude KISS](https://github.com/aphoristicartist/claude-kiss) to **Harnesses & orchestration → Agent infrastructure**.

## Inclusion criteria

- exposes a terminal command and launches the native Claude Code CLI
- preserves Claude Code file, shell, and coding capabilities while controlling its prompt and default tool surface
- points to a public, active, MIT-licensed repository
- includes the current GitHub star count and is placed with the other one-star entries

This adds one factual, non-promotional entry. Disclosure: I maintain Claude KISS.