### PR TITLE
Add Vibestrate (local-first flow orchestrator for CLI coding agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,8 @@ Multi-agent coordination, swarm patterns, and autonomous execution loops. Sorted
 
 - **[TeDDy](https://github.com/atte500/TeDDy)** `⭐ 4` — An opinionated coding harness that prevents code slop by embedding TDD, Hexagonal Architecture, and vertical slicing into a Markdown-driven workflow. Python, AGPL-3.0.
 
+- **[Vibestrate](https://github.com/guyshonshon/vibestrate)** `⭐ 3` — Local-first orchestrator that runs one task through a YAML flow of seated phases: every seat receives the same project rules, auto-derived codebase map, roadmap, and running brief, and the reviewer seat starts a fresh process rather than inheriting the implementer's session, so it reads the diff cold. Approval gates, a git worktree per run, and a local token/cost/decision ledger. Eleven CLIs built in (Claude Code, Codex, Gemini CLI, OpenCode, Aider, Cursor CLI, Amp, Goose, Crush, Qwen Code, Ollama). No cloud component, no telemetry. TypeScript, Apache-2.0.
+
 - **[the-perfect-orchestrator](https://github.com/daman8271/the-perfect-orchestrator)** `⭐ 1` — One lead Claude Code session commands N autonomous workers in tmux panes — spawn, brief, monitor, then adversarially verify results. Pure bash + tmux, zero daemons, coordination via plain files. Also a Claude Code plugin shipping the `/orch` skill. MIT.
 
 ### Agent infrastructure


### PR DESCRIPTION
Adds [Vibestrate](https://github.com/guyshonshon/vibestrate) to **Harnesses & orchestration → Orchestrators & autonomous loops**, star-sorted between TeDDy (4) and the-perfect-orchestrator (1).

Against the inclusion requirements:
- CLI/terminal interface: yes, `vibe` plus a TUI and a local web dashboard. Not IDE-only.
- Reads/writes code and runs commands autonomously: yes, inside a git worktree per run, with your own test suite as the gate.
- Active project: published on npm, Apache-2.0.

What distinguishes it from the neighbouring entries: the through-line is maintained outside the model. Before every turn the orchestrator assembles project rules, an auto-derived codebase map, the roadmap, and a deterministic brief of what has already happened, and hands that to whichever seat is working, so context is not re-established per agent. The reviewer seat never inherits the implementer's session, so cross-model review reads the diff cold rather than ratifying its own reasoning.

Eleven CLIs built in: Claude Code, Codex, Gemini CLI, OpenCode, Aider, Cursor CLI, Amp, Goose, Crush, Qwen Code, and local models via Ollama. No cloud component, no telemetry, keys stay in the vendor CLIs.

Disclosure: I am the author. Happy to adjust the wording, section, or length to fit the list.

Site: https://vibestrate.com