### PR TITLE
Add DevPilot to Orchestrators & autonomous loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,8 @@ Multi-agent coordination, swarm patterns, and autonomous execution loops. Sorted
 
 - **[the-perfect-orchestrator](https://github.com/daman8271/the-perfect-orchestrator)** `⭐ 1` — One lead Claude Code session commands N autonomous workers in tmux panes — spawn, brief, monitor, then adversarially verify results. Pure bash + tmux, zero daemons, coordination via plain files. Also a Claude Code plugin shipping the `/orch` skill. MIT.
 
+- **[DevPilot](https://github.com/geastham/devpilot)** `⭐ 0` — Planning cockpit for a fleet of coding agents: a parallelisation-aware wave planner computes critical paths across a backlog and reports "runway" — how long until the ready-to-dispatch queue empties at current velocity. Dispatches Linear issues to Claude Code sessions on machines you own; the hosted plane never executes an agent or sees source. `npm i -g @devpilot.sh/cli`. MIT.
+
 ### Agent infrastructure
 
 Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by GitHub stars.


### PR DESCRIPTION
Adding [DevPilot](https://github.com/geastham/devpilot) — I'm the author.

It's a planning cockpit for a fleet of coding agents. The angle is the queue rather than the agents: a parallelisation-aware wave planner computes critical paths across a backlog and surfaces **runway** — how long until the ready-to-dispatch queue empties at the fleet's current velocity. Agents execute on machines you own; the hosted plane never runs an agent or sees source.

Checked against the stated inclusion requirements:

- **CLI / terminal interface** — `npm i -g @devpilot.sh/cli`, bin `devpilot`, published at v0.5.14
- **Reads/writes code or runs commands autonomously** — dispatches Linear issues to Claude Code sessions that run to completion on the local machine
- **Valid, active project** — MIT, public, currently alpha

Placed at the end of *Orchestrators & autonomous loops* per the sort-by-stars rule — it's at 0, so it sorts last.

Happy to trim the description or move it to **Session managers & parallel runners** if you think it sits better there.