### PR TITLE
Add OB-1 (open-source terminal coding agent, no API key needed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ Forkable, extensible, and community-driven. Sorted by GitHub stars. Provider tag
 
 - **[Darce](https://github.com/AmerSarhan/darce-cli)** `⭐ 9` — Ultralight (14 kB) multi-model CLI agent built with Ink; 7 tools, smart model routing across providers, streaming, session resume, and slash commands. MIT.
 
+- **[OB-1](https://github.com/Overbrilliant/ob-1)** `⭐ 9` — Terminal coding agent whose default path needs no account, no API key, and no card: an embedded router inside the CLI process answers the first message on keyless free providers, with a signed free-model catalog and failover to your own keys (OpenRouter, OpenAI, Gemini, Groq, Ollama, LM Studio, llama.cpp, vLLM, any OpenAI-compatible endpoint). Persistent SQLite project memory with an inspectable fact/relationship graph, repo map, MCP, and OS sandboxing (Seatbelt/bubblewrap). Keyless tier is a bootstrap path with variable quality and shared limits. npm `@overbrilliant/ob1`. Apache-2.0.
+
 - **[Forge (Norvia Labs)](https://github.com/NorviaLabs/forge)** `⭐ 6` — Rust TUI coding agent unifying an AI agent, a vim-style code editor, and a shell in one keyboard-driven workspace; approval-aware command execution, durable SQLite session journal, and MCP server support. MIT.
 
 - **[CLAII](https://github.com/agencyswarm/CLAII)** `⭐ 5` — CLI-first AI coding agent with multi-agent orchestration, MCP toolchains, and memory-persistent refactors.


### PR DESCRIPTION
Adds **OB-1** (https://github.com/Overbrilliant/ob-1, Apache-2.0) to `Terminal-native coding agents → Open Source`, placed by star count between Darce (⭐ 9) and Forge (⭐ 6).

OB-1 is a terminal coding agent whose default path needs no account, no API key and no card: `npm i -g @overbrilliant/ob1`, run `ob1`, and an embedded router inside the CLI process answers the first message through keyless free providers using a signed bundled free-model catalog — no server or proxy to stand up. It fails over to your own keys (OpenRouter, OpenAI, Gemini, Groq) or local runtimes (Ollama, LM Studio, llama.cpp, vLLM, any OpenAI-compatible endpoint). Beyond the zero-setup start it has persistent SQLite project memory with an inspectable fact/relationship graph, a repo map, MCP support, and OS-level sandboxing (Seatbelt on macOS, bubblewrap on Linux).

To be straight about the trade-off, which the entry states: the keyless tier is a bootstrap path with variable model quality and shared limits, not a frontier-model tier.

Inclusion criteria: CLI/terminal interface ✅, reads/writes code and runs commands autonomously ✅, active repo with a published npm package and Homebrew tap ✅.
