### PR TITLE
Add Mneme — architectural drift prevention for the agentic AI SDLC

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,6 +680,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 - **[claude-northstar](https://github.com/Nisarg38/claude-northstar)** `⭐ 1` — Transforms CLI agents from task executors into autonomous project partners.
 
 - **[Hivelore](https://github.com/Doucs91/hivelore)** `⭐ 1` — Deterministic policy gate for agent-written code: a lesson captured via MCP (`mem_tried`) becomes a validated regex/AST/test guard that Git hooks and CI use to refuse any diff reintroducing the documented mistake; briefs any agent with the team's repo-specific rules over MCP. TypeScript CLI, npm (`@hivelore/cli`). Apache-2.0.
+- **[Mneme](https://github.com/MnemeHQ/mneme)** `⭐ 0` - Architectural drift prevention for the agentic AI SDLC: turns ADRs and repo decisions into deterministic guardrails across AI coding agents via hooks (Claude Code, Codex CLI, Antigravity, Agent SDK). Python, MIT.
+
 
 ---
 


### PR DESCRIPTION
Adds [Mneme](https://github.com/MnemeHQ/mneme) under **Harnesses & orchestration > Agent infrastructure**. Deterministic pre-action guardrails that enforce repo architecture across AI coding agents (Claude Code, Codex CLI, Google Antigravity, Agent SDK). Evidence: [works-with](https://github.com/MnemeHQ/mneme#works-with) + [Codex CLI](https://github.com/MnemeHQ/mneme/blob/main/docs/integrations/codex-cli.md) + [Antigravity](https://github.com/MnemeHQ/mneme/blob/main/docs/integrations/antigravity.md) + [Paperclip compat](https://github.com/MnemeHQ/mneme/blob/main/docs/validation/paperclip-compat-report.md).