### PR TITLE
Add TheGitAI to Closed Source

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,8 @@ Proprietary agents — usable but not forkable or extensible at the source level
 
 - **[Droid](https://github.com/Factory-AI/factory)** `⭐ 10` `[Factory]` — Factory's multi-model CLI coding agent; #1 on Terminal-Bench, specialized droids for different tasks, headless CI mode, and multi-interface support (CLI/IDE/Slack/Linear).
 
+- **[TheGitAI](https://github.com/thegitai/thegitai-cli)** `⭐ 4` — Terminal coding agent across multiple frontier models with no API keys or provider account of your own; server-side web research and checkpointed edits that reverse cleanly. Source-visible client, proprietary server.
+
 - **[FetchCoder](https://github.com/fetchai/fetchcoder-releases)** `⭐ 2` `[Fetch.ai]` — Terminal coding agent powered by ASI1, with interactive TUI, CLI, and API server modes plus MCP integration.
 
 - **[Amp](https://sourcegraph.com/amp)** `[Sourcegraph]` — Sourcegraph's AI coding agent with a CLI for implementing tasks across real codebases.


### PR DESCRIPTION
Adds TheGitAI to *Terminal-native coding agents → Closed Source*.

**Placement:** between Droid (10) and FetchCoder (2), per the star ordering.

Runs against multiple frontier models with no API keys or provider account to manage.
Rust TUI, server-side web research, and assistant edits journaled to checkpoints that
reverse cleanly without touching work you did yourself. Client is source-visible,
server is proprietary.

Repo predates this PR by seven weeks, `@thegitai/cli` has 53 published versions since
2026-06-10, and the client source is under `packages/source-visible-customer-cli/src`.

- Repo: https://github.com/thegitai/thegitai-cli
- Site: https://thegit.ai
- npm: https://www.npmjs.com/package/@thegitai/cli

Disclosure: I work on TheGitAI.
