### PR TITLE
Rename parallel-harness-pets to termagitchi

### DIFF
--- a/README.md
+++ b/README.md
@@ -711,7 +711,7 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[zosma-qa](https://github.com/zosmaai/zosma-qa)** `⭐ 10` — Generates QA agent prompts (planner, generator, healer, analyzer) for CLI coding tools (OpenCode, Claude Code, VS Code Copilot); scaffolds autonomous test workflows across Playwright, Appium, and k6.
 
-- **[parallel-harness-pets](https://github.com/TevvvB/parallel-harness-pets)** `⭐ 10` — Status-line companion for running several agents across git worktrees: each worktree gets its own creature so near-identical terminals are tellable apart, with per-agent context fill and branch hygiene on the row; `pets party` shows every live session at once, worst first. Single static Go binary; Claude Code plugin, Codex hooks, tmux, or any shell prompt. Homebrew and AUR. MIT.
+- **[termagitchi](https://github.com/TevvvB/termagitchi)** `⭐ 10` — Status-line companion for running several agents across git worktrees: each worktree gets its own creature so near-identical terminals are tellable apart, with per-agent context fill and branch hygiene on the row; `pets party` shows every live session at once, worst first. Single static Go binary; Claude Code plugin, Codex hooks, tmux, or any shell prompt. Homebrew and AUR. MIT.
 
 - **[gate4agent](https://github.com/ZENG3LD/gate4agent)** `⭐ 9` `[ZENG3LD]` — Universal Rust transport library for CLI AI agents (Claude Code, Codex, Gemini, OpenCode). Pipe/NDJSON, PTY, and ACP (JSON-RPC 2.0) modes with tokio broadcast fan-out. MIT.
 


### PR DESCRIPTION
Renaming the entry you added in f8ffba6 two days ago. Sorry for the timing - you waited to see whether the project was real, and then it changed its name.

`parallel-harness-pets` -> **termagitchi** (https://github.com/TevvvB/termagitchi). Two readers independently suggested the Tamagotchi pun and it describes the thing better than the old name, which was really our own jargon.

The old GitHub URL redirects permanently, so the existing entry is not broken - this is cosmetic. Your description is unchanged; it was more accurate than the one I originally submitted.

Merge or close as you prefer.