### PR TITLE
Add MulmoTerminal to Session managers & parallel runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,8 @@ Tools for running and managing multiple agent sessions side-by-side. Sorted by G
 
 - **[vibe-tree](https://github.com/sahithvibudhi/vibe-tree)** `⭐ 267` — Execute Claude Code tasks in parallel git worktrees.
 
+- **[MulmoTerminal](https://github.com/receptron/mulmoterminal)** `⭐ 186` — Browser grid of live Claude Code / Codex / Grok sessions started with one `npx` command, no Electron; each cell is a real PTY, colour-coded working / needs-you / done from the CLI's own activity hooks rather than scraped scrollback, with a per-kind chime and Web Push to your phone. tmux-backed persistence across restarts, git worktrees with one-click PRs, and per-session model, context and token readouts. MIT.
+
 - **[Tempest](https://github.com/tempestai-dev/tempest)** `⭐ 159` — Tauri agentic development environment running Claude Code, Codex, Gemini, and other CLI agents in parallel; embedded xterm.js terminals, hook-based per-agent status detection, token-usage intelligence, isolated database branches, and multi-agent session management. Apache-2.0.
 
 - **[CliDeck](https://github.com/rustykuntz/clideck)** `⭐ 152` — WhatsApp-like browser dashboard for managing multiple CLI coding agents (Claude Code, Codex, Gemini CLI, OpenCode) with live status detection, session resume, autopilot routing, and full control from a phone while away. MIT.


### PR DESCRIPTION
Adding **MulmoTerminal** — a browser grid for supervising several Claude Code / Codex sessions at once.

```
- **[MulmoTerminal](https://github.com/receptron/mulmoterminal)** `⭐ 186` — Browser grid of live
  Claude Code / Codex / Grok sessions started with one `npx` command, no Electron; each cell is a
  real PTY, colour-coded working / needs-you / done from the CLI's own activity hooks rather than
  scraped scrollback, with a per-kind chime and Web Push to your phone. tmux-backed persistence
  across restarts, git worktrees with one-click PRs, and per-session model, context and token
  readouts. MIT.
```

**Placement:** sorted by stars, so it sits between vibe-tree (⭐ 267) and Tempest (⭐ 159).

**Against the inclusion criteria:**

- **Terminal interface** — every cell is a real PTY running the `claude` / `codex` CLI you already have installed; it is a cockpit for those CLIs, not a wrapper around an API. Started with `npx mulmoterminal@latest`.
- **Runs commands** — the agents in the cells do, and non-agent cells run anything else (a dev server, `tail -f`) in the same grid.
- **Active** — last push today; MIT.

**What's different from its neighbours in this section:** state comes from the CLI's own activity hooks (`PreToolUse` / `Stop` / `Notification`) rather than from parsing scrollback, so "working" and "waiting on a permission prompt" are distinct rather than both being "output stopped". No Electron or Tauri — it is a local Node server streaming PTYs to xterm.js in your browser, which is also what lets a phone act as a second client.

I'm one of the authors, so please treat this as a suggestion rather than a neutral submission.

---

Unrelated, in case it's useful: a few entries appear twice in the list — `amux`, `CliDeck`, `Data Olympus`, `grite`, `pi-reflect`. Happy to open a separate PR for that if you'd like.