### PR TITLE
Add Tracefold to Agent Infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,6 +717,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[clu](https://github.com/arjia-labs/clu)** `⭐ 8` — Codified Likeness Utility: a SQLite-backed issue tracker for coordinating fleets of AI coding agents. Atomic task claim, dependency graphs, workflows & checkpoints, and an audit log. CLI-native with clean `--json` output, built to be driven by agents. Go.
 
+- **[Tracefold](https://github.com/TraceFold/tracefold)** `⭐ 7` — Verified transformation calculus and undo engine in Rust for CLI agent tool calls and filesystem mutations; escrows pre-commit inverses before effects land, producing signed offline-verifiable DSSE receipts and Merkle tile logs. Apache-2.0.
+
 - **[Terminai](https://github.com/emosenkis/terminai)** `⭐ 6` — Makes your terminal of choice AI-enabled using your favorite CLI coding agent. Completely transparent until you activate the AI with Ctrl-Space, then runs your agent in an overlay with access to your terminal.
 
 - **[OSOP](https://github.com/Archie0125/osop-agent-rules)** `⭐ 5` — Universal workflow logging protocol for CLI coding agents; produces `.osop` workflow definitions and `.osoplog.yaml` execution records. Supports Claude Code, Codex, Cursor, Windsurf, Aider, Cline, Roo Code, Devin, and OpenClaw. Includes a [visual editor](https://osop-editor.vercel.app) and [spec](https://github.com/Archie0125/osop-spec).


### PR DESCRIPTION
### Summary

Adds [Tracefold](https://github.com/TraceFold/tracefold) (\⭐ 7\) to the \Agent infrastructure\ section.

Tracefold is a verified transformation calculus and undo engine in Rust for CLI agent tool calls and filesystem mutations. It escrows pre-commit inverses before effects land, producing signed offline-verifiable DSSE receipts and Merkle tile logs. Apache-2.0.