### PR TITLE
Add Jazz to Open Source terminal-native coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Forkable, extensible, and community-driven. Sorted by GitHub stars. Provider tag
 
 - **[QQCode](https://github.com/qnguyen3/qqcode)** `⭐ 50` — Lightweight CLI coding agent in Rust focused on speed, determinism, and developer control; supports skills.
 
-- **[Jazz](https://github.com/lvndry/jazz)** `⭐ 48` — Agent harness that turns a model into an agent you can run unattended: define a model, persona, toolset, and permissions once in a JSON file, then run the *same* agent — same tools, same memory — in your terminal, from scripts, on a schedule, as a GitHub Action that reviews your PRs, or behind a Telegram/Discord bot you own. 18 providers (incl. local Ollama/llama.cpp) plus any MCP server; built-in file, git, and web tools with permission-gated execution that asks for approval wherever you are.
+- **[Jazz](https://github.com/lvndry/jazz)** `⭐ 48` — Generalist agent harness that runs the *same* agent — same tools, same memory, same permissions — anywhere: your terminal, scripts and pipes, cron/launchd schedules, a GitHub Action that reviews your PRs, or a Telegram/Discord bot you own. Define the agent (model, persona, toolset, permissions) once in a JSON file; it works with 18 providers (incl. local Ollama/llama.cpp) plus any MCP server, and its file, git, and web tools ask for approval wherever you are.
 
 - **[Smelt](https://github.com/leonardcser/smelt)** `⭐ 40` — Rust TUI coding agent; multi-provider (Anthropic, OpenAI, Ollama, GitHub Copilot, any OpenAI-compatible endpoint), four modes (Normal/Plan/Apply/Yolo), granular permission system, parallel subagents, vim keybindings, and headless scriptable mode. MIT.
 

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Forkable, extensible, and community-driven. Sorted by GitHub stars. Provider tag
 
 - **[QQCode](https://github.com/qnguyen3/qqcode)** `⭐ 50` — Lightweight CLI coding agent in Rust focused on speed, determinism, and developer control; supports skills.
 
-- **[Jazz](https://github.com/lvndry/jazz)** `⭐ 48` — Generalist agent harness that runs anywhere: your terminal, scripts and pipes, cron/launchd schedules, a GitHub Action that reviews your PRs, or a Telegram/Discord bot you own. Define one agent (model, persona, toolset, permissions) in a JSON file and it keeps its tools, memory, and permissions on every surface. Works with 18 providers (incl. local Ollama/llama.cpp) plus any MCP server; its file, git, and web tools ask for approval wherever you are.
+- **[Jazz](https://github.com/lvndry/jazz)** `⭐ 48` — Generalist agent harness that runs your agent anywhere: terminal, scripts, cron, a GitHub Action that reviews PRs, or a Telegram/Discord bot you own. Define model, persona, toolset, and permissions in one JSON file; 18 providers (incl. local Ollama/llama.cpp) plus MCP, with permission-gated file, git, and web tools that ask for approval wherever you are.
 
 - **[Smelt](https://github.com/leonardcser/smelt)** `⭐ 40` — Rust TUI coding agent; multi-provider (Anthropic, OpenAI, Ollama, GitHub Copilot, any OpenAI-compatible endpoint), four modes (Normal/Plan/Apply/Yolo), granular permission system, parallel subagents, vim keybindings, and headless scriptable mode. MIT.
 

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Forkable, extensible, and community-driven. Sorted by GitHub stars. Provider tag
 
 - **[QQCode](https://github.com/qnguyen3/qqcode)** `⭐ 50` — Lightweight CLI coding agent in Rust focused on speed, determinism, and developer control; supports skills.
 
-- **[Jazz](https://github.com/lvndry/jazz)** `⭐ 48` — Agent harness that turns a model into an unattended agent: define a model, persona, toolset, and permissions in one JSON file, then run it in your terminal, from scripts, on a schedule, or behind a Telegram/Discord bot you own. 18 providers (incl. local Ollama/llama.cpp) plus MCP; built-in file, git, and web tools with permission-gated execution. MIT.
+- **[Jazz](https://github.com/lvndry/jazz)** `⭐ 48` — Agent harness that turns a model into an agent you can run unattended: define a model, persona, toolset, and permissions once in a JSON file, then run the *same* agent — same tools, same memory — in your terminal, from scripts, on a schedule, as a GitHub Action that reviews your PRs, or behind a Telegram/Discord bot you own. 18 providers (incl. local Ollama/llama.cpp) plus any MCP server; built-in file, git, and web tools with permission-gated execution that asks for approval wherever you are.
 
 - **[Smelt](https://github.com/leonardcser/smelt)** `⭐ 40` — Rust TUI coding agent; multi-provider (Anthropic, OpenAI, Ollama, GitHub Copilot, any OpenAI-compatible endpoint), four modes (Normal/Plan/Apply/Yolo), granular permission system, parallel subagents, vim keybindings, and headless scriptable mode. MIT.
 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,8 @@ Forkable, extensible, and community-driven. Sorted by GitHub stars. Provider tag
 
 - **[QQCode](https://github.com/qnguyen3/qqcode)** `⭐ 50` — Lightweight CLI coding agent in Rust focused on speed, determinism, and developer control; supports skills.
 
+- **[Jazz](https://github.com/lvndry/jazz)** `⭐ 48` — Agent harness that turns a model into an unattended agent: define a model, persona, toolset, and permissions in one JSON file, then run it in your terminal, from scripts, on a schedule, or behind a Telegram/Discord bot you own. 18 providers (incl. local Ollama/llama.cpp) plus MCP; built-in file, git, and web tools with permission-gated execution. MIT.
+
 - **[Smelt](https://github.com/leonardcser/smelt)** `⭐ 40` — Rust TUI coding agent; multi-provider (Anthropic, OpenAI, Ollama, GitHub Copilot, any OpenAI-compatible endpoint), four modes (Normal/Plan/Apply/Yolo), granular permission system, parallel subagents, vim keybindings, and headless scriptable mode. MIT.
 
 - **[Zap](https://github.com/zap-coding-agent/zap-coding-agent)** `⭐ 32` — Skill-first Rust TUI coding agent that injects only the context your task needs — no system prompt bloat. Single binary, no runtime. Supports Claude, Gemini, OpenAI, and local models via LM Studio; code-indexed via SQLite for fast symbol lookup; MCP support. MIT.

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Forkable, extensible, and community-driven. Sorted by GitHub stars. Provider tag
 
 - **[QQCode](https://github.com/qnguyen3/qqcode)** `⭐ 50` — Lightweight CLI coding agent in Rust focused on speed, determinism, and developer control; supports skills.
 
-- **[Jazz](https://github.com/lvndry/jazz)** `⭐ 48` — Generalist agent harness that runs one agent across every surface: your terminal, scripts and pipes, cron/launchd schedules, a GitHub Action that reviews your PRs, or a Telegram/Discord bot you own. The agent keeps its tools, memory, and permissions no matter where it runs. Define it (model, persona, toolset, permissions) once in a JSON file; it works with 18 providers (incl. local Ollama/llama.cpp) plus any MCP server, and its file, git, and web tools ask for approval wherever you are.
+- **[Jazz](https://github.com/lvndry/jazz)** `⭐ 48` — Generalist agent harness that runs anywhere: your terminal, scripts and pipes, cron/launchd schedules, a GitHub Action that reviews your PRs, or a Telegram/Discord bot you own. Define one agent (model, persona, toolset, permissions) in a JSON file and it keeps its tools, memory, and permissions on every surface. Works with 18 providers (incl. local Ollama/llama.cpp) plus any MCP server; its file, git, and web tools ask for approval wherever you are.
 
 - **[Smelt](https://github.com/leonardcser/smelt)** `⭐ 40` — Rust TUI coding agent; multi-provider (Anthropic, OpenAI, Ollama, GitHub Copilot, any OpenAI-compatible endpoint), four modes (Normal/Plan/Apply/Yolo), granular permission system, parallel subagents, vim keybindings, and headless scriptable mode. MIT.
 

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Forkable, extensible, and community-driven. Sorted by GitHub stars. Provider tag
 
 - **[QQCode](https://github.com/qnguyen3/qqcode)** `⭐ 50` — Lightweight CLI coding agent in Rust focused on speed, determinism, and developer control; supports skills.
 
-- **[Jazz](https://github.com/lvndry/jazz)** `⭐ 48` — Generalist agent harness that runs the *same* agent — same tools, same memory, same permissions — anywhere: your terminal, scripts and pipes, cron/launchd schedules, a GitHub Action that reviews your PRs, or a Telegram/Discord bot you own. Define the agent (model, persona, toolset, permissions) once in a JSON file; it works with 18 providers (incl. local Ollama/llama.cpp) plus any MCP server, and its file, git, and web tools ask for approval wherever you are.
+- **[Jazz](https://github.com/lvndry/jazz)** `⭐ 48` — Generalist agent harness that runs one agent across every surface: your terminal, scripts and pipes, cron/launchd schedules, a GitHub Action that reviews your PRs, or a Telegram/Discord bot you own. The agent keeps its tools, memory, and permissions no matter where it runs. Define it (model, persona, toolset, permissions) once in a JSON file; it works with 18 providers (incl. local Ollama/llama.cpp) plus any MCP server, and its file, git, and web tools ask for approval wherever you are.
 
 - **[Smelt](https://github.com/leonardcser/smelt)** `⭐ 40` — Rust TUI coding agent; multi-provider (Anthropic, OpenAI, Ollama, GitHub Copilot, any OpenAI-compatible endpoint), four modes (Normal/Plan/Apply/Yolo), granular permission system, parallel subagents, vim keybindings, and headless scriptable mode. MIT.
 


### PR DESCRIPTION
## Summary
Adds [Jazz](https://github.com/lvndry/jazz) to the **Open Source** section of terminal-native coding agents (sorted by stars, between QQCode ⭐50 and Smelt ⭐40).

Jazz is an agent harness — the loop, guardrails, and surfaces that turn a model into an agent you can run unattended. You define the agent (model, persona, toolset, permissions) in one JSON file and run it in your terminal, from scripts, on a schedule, or behind a Telegram/Discord bot you own. 18 providers (incl. local Ollama/llama.cpp) plus MCP; built-in file, git, and web tools with permission-gated execution. MIT.

## Checklist
- [x] Has a CLI/terminal interface
- [x] Can read/write code and run commands autonomously
- [x] Links to a valid, active GitHub repo
- [x] Entry includes name+link, star count, and 1–2 line description
- [x] Placed in correct section and sorted by stars