### PR TITLE
Add WorkGround2 — local-first AI engineering workbench

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ Forkable, extensible, and community-driven. Sorted by GitHub stars. Provider tag
 
 - **[Ferrum](https://github.com/ominiverdi/ferrum)** `⭐ 2` — Small Linux-only Rust-native coding agent with interactive and headless modes, ACP, safety-tiered native tools, durable JSONL sessions, Codex/ChatGPT OAuth, OpenAI-compatible providers, MCP, skills, and image input. MIT; primary development is on [Codeberg](https://codeberg.org/ominiverdi/ferrum).
 
+- **[WorkGround2](https://github.com/KiddPhenix/WorkGround2)** `⭐ 1` — Local-first AI engineering workbench: one Go agent kernel behind CLI/TUI, web `serve`, a Wails desktop app, and IM bots (Feishu/WeCom/QQ), with multi-model providers, MCP + plugins, project memory, sandboxed/approved execution, and checkpoints + `/rewind`. MIT.
+
 ### OpenClaw ecosystem
 
 Projects built on, forked from, or inspired by [OpenClaw](https://github.com/openclaw/openclaw) — the open-source personal AI assistant. Sorted by GitHub stars.


### PR DESCRIPTION
## What

Adds **[WorkGround2](https://github.com/KiddPhenix/WorkGround2)** to the *Open Source* CLI coding agents section.

WorkGround2 is a **local-first AI engineering workbench** — one Go agent kernel behind four entry points:

- **CLI/TUI** (`workground2`) — terminal-native session
- **`serve`** — HTTP/SSE web frontend
- **Wails desktop app** — completion widget + summaries, no screen-watching
- **IM bots** (Feishu / WeCom / QQ) — relay tasks to a local session

It reads/writes code and runs commands autonomously under a single control chain: multi-model providers (DeepSeek / OpenAI-compatible / Anthropic / local CLI), MCP + plugins (stdio / Streamable HTTP / SSE), project memory (`AGENTS.md` / `WorkGround2.md` / auto memory index), and safe execution (permission policy, sandbox, approval, checkpoints + `/rewind`).

- License: MIT
- Language: Go
- Stars: 1 (early)

## Why it fits

Meets the inclusion requirements: has a CLI/terminal interface, can read/write code and run commands autonomously, and the repo is active. Placed after `Ferrum` (⭐2) per star ordering.

Happy to adjust wording or move sections if it fits better elsewhere.