### PR TITLE
Add SandBase Harness to agent infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,6 +479,8 @@ Multi-agent coordination, swarm patterns, and autonomous execution loops. Sorted
 
 - **[Aeon](https://github.com/aeonfun/aeon)** `⭐ 691` — Autonomous agent framework that runs unattended on GitHub Actions; dispatches skills to six coding-agent harnesses behind one Claude-Code-shaped contract (Claude Code, Grok, Codex, Pi, Vibe, Kimi) on cron or reactive triggers, with quality scoring (1–5 via Haiku), git-persisted memory, a self-healing loop that rewrites underperforming skills, and an MCP server exposing every skill as a tool. 60+ skills across research, dev, crypto, and productivity. MIT.
 
+- **[SandBase Harness](https://github.com/sandbaseai/sandbase-harness)** `⭐ 637` — Local-first TypeScript agent runtime with persistent sessions, sandboxed tools, MCP integration, memory, credentials, audit logs, replay, and CLI/API/Console surfaces. Runs locally or self-hosted with Docker and Kubernetes. Apache-2.0.
+
 - **[h5i](https://github.com/h5i-dev/h5i)** `⭐ 543` — Runs several coding agents (Claude Code, Codex) on the same task in isolated sandboxes, has them peer-review each other, then a neutral verifier replays and tests each candidate and merges the one that passes. Run metadata is versioned in the repo under `refs/h5i/*`. Apache-2.0.
 
 - **[Claudexor](https://github.com/razzant/claudexor)** `⭐ 423` — Local-first control plane that keeps one coding thread across Claude Code, Codex, Cursor, and OpenCode. It can connect multiple user-owned accounts of the same harness (for example, five Claude Code accounts or ten Codex accounts), track each account's quota, and opt in to automatic rotation when one reaches its limit. CLI + macOS app. MIT.


### PR DESCRIPTION
## Summary
- add SandBase Harness to the Agent infrastructure section
- describe its local-first runtime, persistent sessions, sandboxed tools, MCP, memory, credentials, audit, replay, and deployment surfaces
- place the entry according to the current GitHub star count and section ordering

The description and Apache-2.0 license are based on the official SandBase Harness repository.