### PR TITLE
Add Agent Fleet to Agent infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -746,6 +746,7 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 - **[UACOS](https://github.com/caotiensinh/uacos)** `⭐ 1` — Local-first code intelligence and orchestration toolkit: dependency-graph impact analysis, context compression, patch-scope safety gates, transaction rollback, and a job-based runtime for coding agents. No cloud dependency. Python, MIT.
 
 - **[stratless](https://github.com/stratless-ai/stratless)** `⭐ 0` — Derives Claude Code and Codex skills from your own session history: clusters recurring moments locally, has your own assistant name them, and cites the evidence count behind every proposed skill before installing to `~/.claude/skills`. Zero runtime dependencies, nothing leaves the machine. npm `stratless`, TypeScript. MIT.
+- **[Agent Fleet](https://woodor.ai/agent-fleet/)** — Messaging layer for coding-agent sessions: every live Claude Code or Codex session takes a `name@project` address, and sessions exchange messages and files on one machine, across a LAN, or across networks. Also does remote session lifecycle control — compact, clear, handoff, restart. Native on macOS and Windows (x64 and arm64), no WSL and no tmux. Closed source; free on a local network, paid cloud relay.
 
 ---
 


### PR DESCRIPTION
Adds Agent Fleet to Harnesses & orchestration → Agent infrastructure.

What it is: a messaging layer for coding-agent sessions. Each live Claude Code or Codex session registers a `name@project` address; sessions then send each other messages and files on one machine, across a local network, or across networks. It also does remote session lifecycle control — compact, clear, handoff, restart.

Why this section: it sits next to Okto Nexus — the same category of identities, presence, and messages between agents — rather than being a session manager or a GUI.

No star count: there is no public repository, so the entry links to the product page, following the format used by Unpeel and CodeAgentSwarm in the neighbouring section.

Platforms: macOS and Windows, x64 and arm64, native — no WSL, no tmux. Closed source; free on a local network, paid cloud relay.

Disclosure: I am the author.