### PR TITLE
Add pond to Agent infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -645,6 +645,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[AgentTier](https://github.com/agenttier/agenttier)** `⭐ 60` — Kubernetes-native sandbox runtime for AI coding agents. A `Sandbox` CRD provisions a Pod + PVC + NetworkPolicy with optional gVisor isolation; the `agenttier` Go CLI runs agent invocations that stream stdout/stderr/exit as SSE. Ships reference templates for Claude Code + Bedrock and LangGraph. Apache-2.0.
 
+- **[pond](https://github.com/tenequm/pond)** `⭐ 58` — Lossless session archive for coding agents: ingests what twelve harnesses already write (Claude Code, Codex, opencode, pi, OpenClaw, Hermes, letta-code, grok-build and more) into Lance on a local directory or your own S3 bucket, then serves recall back over CLI, MCP, HTTP, and read-only SQL. Sessions outlive harness retention windows and restore into any supported client. Rust, Apache-2.0.
+
 - **[Nex](https://github.com/nex-crm/nex-as-a-skill)** `⭐ 55` — Organizational context and memory for AI agents; connects email, Slack, CRM, and 100+ tools into one knowledge graph with a 60-tool MCP server (`npx @nex-ai/nex`) and persistent memory across agent sessions. MIT.
 
 - **[claudebox](https://github.com/numtide/claudebox)** `⭐ 55` — Sandboxed environment for Claude Code (focused on isolation/safety).


### PR DESCRIPTION
pond is the session archive layer for CLI coding agents. It ingests the session files twelve harnesses already write - Claude Code, Codex CLI, opencode, pi, oh-my-pi, OpenClaw, NanoClaw, Hermes, letta-code, grok-build, Claude desktop, claude.ai export - into Lance on a local directory or your own S3 bucket, and serves recall back over the `pond` CLI, MCP, HTTP+JSON, and read-only SQL. Any stored session can be restored into any supported client, so history is not locked to the tool that wrote it.

Why it belongs in Agent infrastructure: harnesses prune their own history (Claude Code deletes transcripts after 30 days by default) and each one can only see its own machine. pond keeps everything, in storage the user owns, and hands it back to whichever agent asks. Closest neighbours already listed are Vestige and numbat.

Against the contributing criteria: terminal CLI (`pond init`, `pond sync`, `pond search`, `pond serve`), active project (v0.17.0, commits most days since May 2026), Apache-2.0, single Rust binary via Homebrew, Scoop, Nix, cargo, or a release zip. Entry placed in star order at 58, between AgentTier (60) and Nex (55), in the existing format with a license note.

Disclosure: I am the author.
