### PR TITLE
Add OrcaReplay to Agent infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,6 +639,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[pi-mem](https://github.com/jo-inc/pi-mem)** `⭐ 73` — Plain-Markdown persistent memory for coding agents; long-term, daily, scratchpad, and searchable notes with zero dependencies on vector DBs. MIT.
 
+- **[OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay)** `⭐ 73` — Records a coding-agent run and replays it offline byte-for-byte, or forks it from any checkpoint onto a different model. Capture sits below the harness — shell exit codes, per-turn file changes and MCP calls land on the same timeline as the model traffic — so it also records agents with no base URL to change, via TLS interception on a host allowlist.
+
 - **[Untether](https://github.com/littlebearapps/untether)** `⭐ 66` — Telegram bridge for 6 CLI coding agents (Claude Code, Codex, OpenCode, Pi, Gemini CLI, Amp); remote task control via voice or text, progress streaming, interactive permissions, and cost tracking. MIT.
 
 - **[brood-box](https://github.com/stacklok/brood-box)** `⭐ 64` — Hardware-isolated microVM sandbox for AI coding agents (Claude Code, Codex, OpenCode) with COW snapshot isolation, egress control, and MCP authorization.


### PR DESCRIPTION
Adds [OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) to **Harnesses & orchestration → Agent infrastructure**, placed by star count after `pi-mem` (both at 73).

Records a coding-agent run and replays it offline, or forks it from a checkpoint onto another model. Closest neighbour in this section is Headroom — also a proxy plus MCP server wrapping several agents; the difference is that the trace viewers here read a run after the fact and this one re-executes it.

- CLI/terminal interface — `orca record` / `replay` / `fork` / `compare` (npm `orcareplay`, Node 20+)
- Active, link valid
- On the second requirement: it records the agents that read and write code rather than doing so itself, which is how I read the observability and sandbox entries in this section too. Say the word and I'll withdraw.

Disclosure: I work on OrcaReplay.