### PR TITLE
Add Superagent to Session managers & parallel runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,8 @@ Tools for running and managing multiple agent sessions side-by-side. Sorted by G
 
 - **[intentic](https://github.com/intentic/intentic)** `⭐ 30` — Self-hosted workspace that gives each coding agent a persistent sandbox on hardware you own: agents work in real checkouts in their own git worktrees behind PTY terminals, and you approve the riskier calls and read every diff before it lands. A Rust host agent pairs the machine over an outbound-only Cloudflare tunnel, so there are no inbound ports to open; the workspace opens in any browser or the desktop app. Runs Claude Code, Codex, Grok, Kimi Code, and Gemini on your own subscriptions. TypeScript, MIT.
 
+- **[Superagent](https://github.com/pungme/superagent-desktop)** `⭐ 24` — macOS desktop client for Claude Code and Codex: gives the agent a real browser it can navigate and drive, an iOS Simulator window for installing and screenshotting apps, and a phone companion app for remote monitoring over an end-to-end encrypted relay. Electron, SwiftUI, and a Cloudflare Worker relay. MIT.
+
 - **[agents-cli](https://github.com/phnx-labs/agents-cli)** `⭐ 18` — CLI to install, version-pin, and run many coding-agent harnesses (Claude Code, Codex, Gemini CLI, Cursor, OpenCode, Grok); shared skills/MCP/rules, parallel teams in isolated terminals, session index, and SSH fleet dispatch. npm `@phnx-labs/agents-cli`. Apache-2.0.
 
 - **[repomon](https://github.com/AliHamzaAzam/repomon)** `⭐ 17` — Run a fleet of AI coding agents (Claude Code, Codex, Aider) across many repos, branches, and git worktrees from one tmux-backed terminal. Four-zoom TUI (fleet, split, babysit grid, focus), needs-you triage, durable sessions that survive restarts.


### PR DESCRIPTION
Adds Superagent to Session managers & parallel runners.

Superagent is an open-source (MIT) macOS desktop app that gives Claude Code / Codex a real environment to act in: a browser it can navigate and drive, an iOS Simulator window it can install apps into and screenshot, and a phone companion app + relay so you can watch/drive a session remotely from your phone (similar spirit to Unpeel's phone-relay feature, already listed in this section).

Repo: https://github.com/pungme/superagent-desktop
Stars: 24 (placed between intentic and agents-cli per the star-sort convention)
License: MIT