### PR TITLE
Add Nausicaa to terminal-native coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ Forkable, extensible, and community-driven. Sorted by GitHub stars. Provider tag
 
 - **[Ferrum](https://github.com/ominiverdi/ferrum)** `⭐ 2` — Small Linux-only Rust-native coding agent with interactive and headless modes, ACP, safety-tiered native tools, durable JSONL sessions, Codex/ChatGPT OAuth, OpenAI-compatible providers, MCP, skills, and image input. MIT; primary development is on [Codeberg](https://codeberg.org/ominiverdi/ferrum).
 
+- **[Nausicaa](https://github.com/jackispm/nausicaa-harness)** `⭐ 1` — TypeScript CLI/runtime for general-purpose agent tasks with addressable Lanes, an optional Teto observer lane, durable Run ledgers, daemon/worker lifecycle, and cross-Run A2A. npm `nausicaa-harness`, MIT.
+
 ### OpenClaw ecosystem
 
 Projects built on, forked from, or inspired by [OpenClaw](https://github.com/openclaw/openclaw) — the open-source personal AI assistant. Sorted by GitHub stars.


### PR DESCRIPTION
## Summary\n\n- Add Nausicaa to the Open Source terminal-native coding agents section.\n- Describe its general-purpose TypeScript CLI/runtime, addressable Lanes, optional Teto observer lane, durable Run ledgers, daemon/worker lifecycle, and cross-Run A2A.\n- Include the public npm package and MIT license.\n\nThe entry is placed in the existing one-entry format and ordered at the current one-star boundary.