### PR TITLE
Add llm-panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -747,6 +747,8 @@ Sandboxes, routers, browser/terminal automation, and extension tools. Sorted by 
 
 - **[stratless](https://github.com/stratless-ai/stratless)** `⭐ 0` — Derives Claude Code and Codex skills from your own session history: clusters recurring moments locally, has your own assistant name them, and cites the evidence count behind every proposed skill before installing to `~/.claude/skills`. Zero runtime dependencies, nothing leaves the machine. npm `stratless`, TypeScript. MIT.
 
+- **[llm-panel](https://github.com/musharna/llm-panel)** `⭐ 0` — Put one question or diff to several LLM CLIs in parallel (codex, claude, opencode/OpenRouter, ollama); every answer shown in full, an anonymised rebuttal round, cost accounting, a GitHub Action, and a measured miss rate on AACR-Bench. Python, PyPI `llm-panel`. MIT.
+
 ---
 
 ## Contributing


### PR DESCRIPTION
Adds **llm-panel** to *Harnesses & orchestration → Agent infrastructure*.

- Name + link: [llm-panel](https://github.com/musharna/llm-panel)
- Star count: `⭐ 0` (new project)
- Description: puts one question or diff to several LLM CLIs in parallel (codex, claude, opencode/OpenRouter, ollama); every answer shown in full, an anonymised rebuttal round, cost accounting, a GitHub Action, and a measured miss rate on AACR-Bench. Python, PyPI `llm-panel`, MIT.

Fit: it is not a coding agent itself but a CLI tool that drives the installed coding-agent CLIs as parallel judges (review a diff, answer a question), so I placed it under Agent infrastructure ("extension tools") next to entries like OpenCodeReview and context-bridge. Happy to move it if you prefer another section.

Placed at the end of the section per star-count ordering; `scripts/update-stars.py` parses the entry and leaves it in place.